### PR TITLE
ForwardDiff for jacobian computation

### DIFF
--- a/src/ProbNumDiffEq.jl
+++ b/src/ProbNumDiffEq.jl
@@ -26,6 +26,7 @@ using RecipesBase
 using ModelingToolkit
 using RecursiveArrayTools
 using StaticArrays
+using ForwardDiff
 
 
 # @reexport using PSDMatrices

--- a/src/caches.jl
+++ b/src/caches.jl
@@ -48,11 +48,6 @@ function OrdinaryDiffEq.alg_cache(
               "or a matrix) are currently not supported")
     end
 
-    if (alg isa EK1 || alg isa IEKS) && isnothing(f.jac)
-        error("EK1 requires the Jacobian. To automatically generate it with ",
-              "ModelingToolkit.jl use ProbNumDiffEq.remake_prob_with_jac(prob).")
-    end
-
     q = alg.order
     d = length(u)
     D = d*(q+1)

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -8,12 +8,6 @@ import DiffEqProblemLibrary.ODEProblemLibrary: prob_ode_linear, prob_ode_2Dlinea
 import ProbNumDiffEq: remake_prob_with_jac
 
 
-@testset "EK1 requires Jac" begin
-    prob = prob_ode_lotkavoltera
-    @test_throws ErrorException solve(prob, EK1())
-    @test solve(remake_prob_with_jac(prob), EK1()) isa ProbNumDiffEq.ProbODESolution
-end
-
 @testset "One-dim problems don't work so far!" begin
     prob = prob_ode_linear
     @test_throws ErrorException solve(prob, EK0())


### PR DESCRIPTION
Compute Jacobians not only when supplied in the problem, but rely on ForwardDiff if necessary.