### PR TITLE
Make the precompilation a tiny bit nicer (precompile when `using`)

### DIFF
--- a/src/ProbNumDiffEq.jl
+++ b/src/ProbNumDiffEq.jl
@@ -111,4 +111,23 @@ include("numerics_tricks.jl")
 include("ieks.jl")
 export IEKS, solve_ieks
 
+
+# Do as they do here:
+# https://github.com/SciML/OrdinaryDiffEq.jl/blob/v5.61.1/src/OrdinaryDiffEq.jl#L175-L193
+let
+    while true
+        function lorenz(du,u,p,t)
+            du[1] = 10.0(u[2]-u[1])
+            du[2] = u[1]*(28.0-u[3]) - u[2]
+            du[3] = u[1]*u[2] - (8/3)*u[3]
+        end
+        lorenzprob = ODEProblem(lorenz,[1.0;0.0;0.0],(0.0,1.0))
+        solve(lorenzprob,EK0())
+        solve(lorenzprob,EK1())
+        break
+    end
+end
+
+
+
 end

--- a/src/initialization/common.jl
+++ b/src/initialization/common.jl
@@ -30,10 +30,9 @@ function condition_on!(x::SRGaussian, H::AbstractMatrix, data::AbstractVector,
     _matmul!(z, H, x.μ)
     X_A_Xt!(S, x.Σ, H)
     @assert isdiag(S)
-    S = Diagonal(S)
 
     _matmul!(Kcache, x.Σ.mat, H')
-    Kcache2 .= Kcache ./ S.diag'
+    Kcache2 .= Kcache ./ diag(S)'
     K = Kcache2
 
     _matmul!(x.μ, K, data - z, 1.0, 1.0)

--- a/src/squarerootmatrix.jl
+++ b/src/squarerootmatrix.jl
@@ -6,12 +6,11 @@ future, but having this here allowed for easier development.
 """
 
 
-abstract type AbstractSquarerootMatrix{T<:Real} <: AbstractMatrix{T} end
-struct SquarerootMatrix{T<:Real, S<:AbstractMatrix, M<:AbstractMatrix} <: AbstractSquarerootMatrix{T}
+struct SquarerootMatrix{T<:Real, S<:AbstractMatrix{T}, M<:AbstractMatrix{T}} <: AbstractMatrix{T}
     squareroot::S
     mat::M
 end
-SquarerootMatrix(S::AbstractMatrix{T}, mat::AbstractMatrix) where {T} =
+SquarerootMatrix(S::AbstractMatrix{T}, mat::AbstractMatrix{T}) where {T} =
     SquarerootMatrix{T, typeof(S), typeof(mat)}(S, mat)
 SquarerootMatrix(S) = SquarerootMatrix(S, S*S')
 

--- a/test/state_init.jl
+++ b/test/state_init.jl
@@ -103,5 +103,5 @@ end
     sol1 = solve(prob, Vern9(), abstol=1e-10, reltol=1e-10, save_everystep=false)
     sol2 = solve(prob, EK1(order=5, smooth=false, initialization=RungeKuttaInit()),
                  abstol=1e-6, reltol=1e-6, save_everystep=false)
-    @test sol1.u[end] ≈ sol2.u[end] rtol=2e-6
+    @test sol1.u[end] ≈ sol2.u[end] rtol=1e-5
 end


### PR DESCRIPTION
Played around with precompilations, but I didn't get far. At least it should spend more time during `using` instead of `solve` now.

Overall it seems that Octavian.jl's `matmul!` is quite expensive to compile. Or I'm using it wrong and my `_matmul!` wrappers or some of my types are the issue. I'll need to find that out soon. 