### PR TITLE
Improve the TaylorMode Initialization for SecondOrderODEProblems

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProbNumDiffEq"
 uuid = "bf3e78b0-7d74-48a5-b855-9609533b56a5"
 authors = ["Nathanael Bosch"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/src/initialization/taylormode.jl
+++ b/src/initialization/taylormode.jl
@@ -9,14 +9,16 @@ function initial_update!(integ, cache, init::TaylorModeInit)
     f_derivatives = taylormode_get_derivatives(u, f, p, t, q)
     @assert length(0:q) == length(f_derivatives)
     for (o, df) in zip(0:q, f_derivatives)
+        if f isa DynamicalODEFunction
+            @assert df isa ArrayPartition
+            df = df[2, :]
+        end
         condition_on!(x, Proj(o), view(df, :), m_tmp, K1, K2, x_tmp.Σ, x_tmp2.Σ.mat)
     end
 end
 
 """
     Compute initial derivatives of an OOP ODEProblem with TaylorSeries.jl
-
-    Warning: The OOP version is much slower than the IIP version!
 """
 function taylormode_get_derivatives(u, f::AbstractODEFunction{false}, p, t, q)
     f = oop_to_iip(f)
@@ -40,35 +42,4 @@ function taylormode_get_derivatives(u, f::AbstractODEFunction{true}, p, t, q)
     uauxT = similar(uT)
     TaylorIntegration.jetcoeffs!(f, tT, uT, duT, uauxT, p)
     return [evaluate.(differentiate.(uT, i)) for i in 0:q]
-end
-
-"""
-    Compute initial derivatives of a SecondOrderODE with TaylorSeries.jl
-"""
-function taylormode_get_derivatives(u::ArrayPartition, f::DynamicalODEFunction, p, t, q)
-    d = length(u[1, :])
-    Proj = projection(d, q, eltype(u))
-
-    f_oop(du, u, p, t) =
-        !isinplace(f.f1) ? f.f1(du, u, p, t) :
-        (ddu = copy(du); f.f1(ddu, du, u, p, t); return ddu)
-
-    # Make sure that the vector field f does not depend on t
-    f_t_taylor = taylor_expand(_t -> f_oop(u[1:d], u[d+1:end], p, _t), t)
-    @assert !(eltype(f_t_taylor) <: TaylorN) "The vector field depends on t; The code might not yet be able to handle these (but it should be easy to implement)"
-
-    set_variables("u", numvars=2d, order=q + 1)
-
-    fp1 = taylor_expand(u -> f_oop(u[1:d], u[d+1:end], p, t), u[:])
-    fp2 = taylor_expand(u -> u[1:d], u[:])
-    f_derivatives = [fp1]
-    for o in 3:q
-        _curr_f_deriv = f_derivatives[end]
-        dfdu1 = stack([derivative.(_curr_f_deriv, i) for i in 1:d])'
-        dfdu2 = stack([derivative.(_curr_f_deriv, i) for i in d+1:2d])'
-        df = dfdu1 * fp1 + dfdu2 * fp2
-        push!(f_derivatives, df)
-    end
-
-    return [u[2, :], u[1, :], evaluate.(f_derivatives)...]
 end

--- a/test/specific_problems.jl
+++ b/test/specific_problems.jl
@@ -64,12 +64,6 @@ end
 @testset "scalar-valued problem" begin
     @testset "$alg" for alg in [EK0(), EK1()]
         @test_broken solve(prob_ode_linear, alg) isa ProbNumDiffEq.ProbODESolution
-        # sol = solve(prob_ode_linear, alg)
-
-        # @test length(sol.u[1]) == length(sol.pu.μ[1])
-        # @test sol.u[1] == sol.pu.μ[1][1]
-        # @test sol.u ≈ sol.u_analytic rtol=1e-4
-        # @test plot(sol) isa AbstractPlot
     end
 end
 


### PR DESCRIPTION
It now also uses TaylorIntegration.jl, and from what I could see so far it seems to scale quite well to higher-dimensional problems! At least, solving the Pleiades with orders > 5 is not really an issue anymore, which is good.