### PR TITLE
`ManifoldUpdate` callback

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProbNumDiffEq"
 uuid = "bf3e78b0-7d74-48a5-b855-9609533b56a5"
 authors = ["Nathanael Bosch"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/src/ProbNumDiffEq.jl
+++ b/src/ProbNumDiffEq.jl
@@ -122,6 +122,8 @@ include("ieks.jl")
 export IEKS, solve_ieks
 
 include("devtools.jl")
+include("callbacks.jl")
+export ManifoldUpdate
 
 # Do as they do here:
 # https://github.com/SciML/OrdinaryDiffEq.jl/blob/v5.61.1/src/OrdinaryDiffEq.jl#L175-L193

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -1,0 +1,19 @@
+function ManifoldUpdate(residualf)
+    condition(u, t, integ) = true
+
+    function affect!(integ)
+        @unpack u = integ
+        @unpack x, SolProj = integ.cache
+
+        f(m) = residualf(SolProj * m)
+
+        m, C = x
+        z = f(m)
+        J = ForwardDiff.jacobian(f, m)
+        S = X_A_Xt(C, J)
+
+        x_out = update(x, Gaussian(z, S), J)
+        copy!(x, x_out)
+    end
+    DiscreteCallback(condition, affect!)
+end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -14,6 +14,7 @@ function ManifoldUpdate(residualf)
 
         x_out = update(x, Gaussian(z, S), J)
         copy!(x, x_out)
+        return nothing
     end
-    DiscreteCallback(condition, affect!)
+    return DiscreteCallback(condition, affect!)
 end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -1,4 +1,4 @@
-function ManifoldUpdate(residualf)
+function ManifoldUpdate(residualf; maxiters=100, ϵ₁=1e-25, ϵ₂=1e-15)
     condition(u, t, integ) = true
 
     function affect!(integ)
@@ -8,12 +8,23 @@ function ManifoldUpdate(residualf)
         f(m) = residualf(SolProj * m)
 
         m, C = x
-        z = f(m)
-        J = ForwardDiff.jacobian(f, m)
-        S = X_A_Xt(C, J)
+        m_i = copy(m)
 
-        x_out = update(x, Gaussian(z, S), J)
-        copy!(x, x_out)
+        local m_i_new, C_i_new
+        for i in 1:maxiters
+            z = f(m_i)
+            J = ForwardDiff.jacobian(f, m_i)
+            S = X_A_Xt(C, J)
+
+            m_i_new, C_i_new = update(x, Gaussian(z .+ (J * (m - m_i)), S), J)
+
+            if norm(m_i_new .- m_i) < ϵ₁ && norm(z) < ϵ₂
+                break
+            end
+            m_i = m_i_new
+        end
+        copy!(x, Gaussian(m_i_new, C_i_new))
+
         return nothing
     end
     return DiscreteCallback(condition, affect!)

--- a/src/filtering/update.jl
+++ b/src/filtering/update.jl
@@ -21,6 +21,17 @@ function update(x::Gaussian, measurement::Gaussian, H::AbstractMatrix)
 
     return Gaussian(m_new, C_new)
 end
+function update(x::SRGaussian, measurement::SRGaussian, H::AbstractMatrix)
+    """In Joseph form"""
+    m, C = x
+    z, S = measurement
+
+    K = C * H' * inv(S)
+    m_new = m - K * z
+    C_new = X_A_Xt(C, (I - K*H))
+
+    return Gaussian(m_new, C_new)
+end
 
 """
     update!(x_out, x_pred, measurement, H, R=0)

--- a/src/filtering/update.jl
+++ b/src/filtering/update.jl
@@ -28,7 +28,7 @@ function update(x::SRGaussian, measurement::SRGaussian, H::AbstractMatrix)
 
     K = C * H' * inv(S)
     m_new = m - K * z
-    C_new = X_A_Xt(C, (I - K*H))
+    C_new = X_A_Xt(C, (I - K * H))
 
     return Gaussian(m_new, C_new)
 end

--- a/test/specific_problems.jl
+++ b/test/specific_problems.jl
@@ -126,7 +126,8 @@ end
     E(u) = [dot(u, u) - 2]
 
     @test solve(prob, EK0(order=3)) isa ProbNumDiffEq.ProbODESolution
-    @test solve(prob, EK0(order=3), callback=ManifoldUpdate(E)) isa ProbNumDiffEq.ProbODESolution
+    @test solve(prob, EK0(order=3), callback=ManifoldUpdate(E)) isa
+          ProbNumDiffEq.ProbODESolution
 end
 
 @testset "Problem definition with ParameterizedFunctions.jl" begin

--- a/test/specific_problems.jl
+++ b/test/specific_problems.jl
@@ -114,6 +114,21 @@ end
     @test solve(prob, EK0(order=3), callback=Callback()) isa ProbNumDiffEq.ProbODESolution
 end
 
+@testset "ManifoldUpdate callback test" begin
+    # Again: Harmonic Oscillator with condition on E=2
+    u0 = ones(2)
+    function harmonic_oscillator(du, u, p, t)
+        du[1] = u[2]
+        return du[2] = -u[1]
+    end
+    prob = ODEProblem(harmonic_oscillator, u0, (0.0, 100.0))
+
+    E(u) = [dot(u, u) - 2]
+
+    @test solve(prob, EK0(order=3)) isa ProbNumDiffEq.ProbODESolution
+    @test solve(prob, EK0(order=3), callback=ManifoldUpdate(E)) isa ProbNumDiffEq.ProbODESolution
+end
+
 @testset "Problem definition with ParameterizedFunctions.jl" begin
     f = @ode_def LotkaVolterra begin
         dx = a * x - b * x * y


### PR DESCRIPTION
The probabilistic, Kalman-filtering equivalent to `DiffEqCallback.jl`'s `ManifoldProjection`. 

The callback does one single update on a given information operator `(u) -> residual`. The update assumes that the residual should be zero.

It is also non-iterative, and therefore probably not as 100% reliable as the optimization-based `ManifoldProjection`, but this should be easily expandable by performing iterated updates (as in the IEKF).

EDIT: It's an IEKF update now :heavy_check_mark: 