### PR TITLE
New algorithm: EK1 with additional updates on second derivative information

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProbNumDiffEq"
 uuid = "bf3e78b0-7d74-48a5-b855-9609533b56a5"
 authors = ["Nathanael Bosch"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/src/ProbNumDiffEq.jl
+++ b/src/ProbNumDiffEq.jl
@@ -93,7 +93,7 @@ include("initialization/common.jl")
 export TaylorModeInit, RungeKuttaInit
 
 include("algorithms.jl")
-export EK0, EK1
+export EK0, EK1, EK1FDB
 
 include("alg_utils.jl")
 include("caches.jl")

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -50,3 +50,12 @@ Base.@kwdef struct EK1{IT} <: AbstractEK
     smooth::Bool = true
     initialization::IT = TaylorModeInit()
 end
+
+Base.@kwdef struct EK1FDB{IT} <: AbstractEK
+    prior::Symbol = :ibm
+    order::Int = 3
+    diffusionmodel::Symbol = :dynamic
+    smooth::Bool = true
+    initialization::IT = TaylorModeInit()
+    jac_quality::Int = 1
+end

--- a/src/caches.jl
+++ b/src/caches.jl
@@ -145,6 +145,14 @@ function OrdinaryDiffEq.alg_cache(
     C2 = SRMatrix(zeros(uElType, D, 3D), zeros(uElType, D, D))
     covmatcache = similar(G)
 
+    if alg isa EK1FDB
+        H = [E1; E2]
+        v = [v; v]
+        S = SRMatrix(zeros(uElType, 2d, D), zeros(uElType, 2d, 2d))
+        measurement = Gaussian(v, S)
+        K = zeros(uElType, D, 2d)
+    end
+
     diffmodel =
         alg.diffusionmodel == :dynamic ? DynamicDiffusion() :
         alg.diffusionmodel == :fixed ? FixedDiffusion() :

--- a/test/correctness.jl
+++ b/test/correctness.jl
@@ -21,12 +21,15 @@ for (prob, probname) in [
         true_sol =
             solve(remake(prob, u0=big.(prob.u0)), Tsit5(), abstol=1e-20, reltol=1e-20)
 
-        for Alg in (EK0, EK1),
+        EK1FDB1(; kwargs...) = EK1FDB(; jac_quality=1, kwargs...)
+        EK1FDB2(; kwargs...) = EK1FDB(; jac_quality=2, kwargs...)
+        EK1FDB3(; kwargs...) = EK1FDB(; jac_quality=3, kwargs...)
+        for Alg in (EK0, EK1, EK1FDB1, EK1FDB2, EK1FDB3),
             diffusion in [:fixed, :dynamic, :fixedMV, :dynamicMV],
             init in [TaylorModeInit(), RungeKuttaInit()],
             q in [2, 3, 5]
 
-            if Alg == EK1 && diffusion in (:fixedMV, :dynamicMV)
+            if diffusion in (:fixedMV, :dynamicMV) && Alg != EK0
                 continue
             end
 
@@ -55,12 +58,15 @@ for (prob, probname) in [
             solve(remake(prob, u0=big.(prob.u0)), Tsit5(), abstol=1e-20, reltol=1e-20)
         true_dense_vals = true_sol.(t_eval)
 
-        for Alg in (EK0, EK1),
+        EK1FDB1(; kwargs...) = EK1FDB(; jac_quality=1, kwargs...)
+        EK1FDB2(; kwargs...) = EK1FDB(; jac_quality=2, kwargs...)
+        EK1FDB3(; kwargs...) = EK1FDB(; jac_quality=3, kwargs...)
+        for Alg in (EK0, EK1, EK1FDB1, EK1FDB2, EK1FDB3),
             diffusion in [:fixed, :dynamic, :fixedMV, :dynamicMV],
             init in [TaylorModeInit(), RungeKuttaInit()],
             q in [2, 3, 5]
 
-            if Alg == EK1 && diffusion in (:fixedMV, :dynamicMV)
+            if diffusion in (:fixedMV, :dynamicMV) && Alg != EK0
                 continue
             end
 

--- a/test/specific_problems.jl
+++ b/test/specific_problems.jl
@@ -66,11 +66,47 @@ end
     @test sol isa ProbNumDiffEq.ProbODESolution
 end
 
-@testset "OOP problem definition" begin
-    prob = ODEProblem((u, p, t) -> ([p[1] * u[1] .* (1 .- u[1])]), [1e-1], (0.0, 5), [3.0])
-    @test solve(prob, EK0(order=4)) isa ProbNumDiffEq.ProbODESolution
-    prob = ProbNumDiffEq.remake_prob_with_jac(prob)
-    @test solve(prob, EK1(order=4)) isa ProbNumDiffEq.ProbODESolution
+@testset "IIP problem" begin
+    f(du, u, p, t) = (du[1] = p[1] * u[1] .* (1 .- u[1]))
+    prob = ODEProblem(f, [1e-1], (0.0, 5), [3.0])
+    @testset "without jacobian" begin
+        @test solve(prob, EK0(order=4)) isa ProbNumDiffEq.ProbODESolution
+        # first without defined jac
+        @test solve(prob, EK1(order=4)) isa ProbNumDiffEq.ProbODESolution
+        @test solve(prob, EK1FDB(order=4, jac_quality=1)) isa ProbNumDiffEq.ProbODESolution
+        @test solve(prob, EK1FDB(order=4, jac_quality=2)) isa ProbNumDiffEq.ProbODESolution
+        @test solve(prob, EK1FDB(order=4, jac_quality=3)) isa ProbNumDiffEq.ProbODESolution
+    end
+    @testset "with jacobian" begin
+        # now with defined jac
+        prob = ProbNumDiffEq.remake_prob_with_jac(prob)
+        @test solve(prob, EK1(order=4)) isa ProbNumDiffEq.ProbODESolution
+        @test solve(prob, EK1FDB(order=4, jac_quality=1)) isa ProbNumDiffEq.ProbODESolution
+        @test solve(prob, EK1FDB(order=4, jac_quality=2)) isa ProbNumDiffEq.ProbODESolution
+        @test solve(prob, EK1FDB(order=4, jac_quality=3)) isa ProbNumDiffEq.ProbODESolution
+    end
+end
+
+@testset "OOP problem" begin
+    f(u, p, t) = ([p[1] * u[1] .* (1 .- u[1])])
+    prob = ODEProblem(f, [1e-1], (0.0, 5), [3.0])
+    @testset "without jacobian" begin
+        # first without defined jac
+        @test solve(prob, EK0(order=4)) isa ProbNumDiffEq.ProbODESolution
+        @test solve(prob, EK1(order=4)) isa ProbNumDiffEq.ProbODESolution
+        @test solve(prob, EK1FDB(order=4, jac_quality=1)) isa ProbNumDiffEq.ProbODESolution
+        @test solve(prob, EK1FDB(order=4, jac_quality=2)) isa ProbNumDiffEq.ProbODESolution
+        @test solve(prob, EK1FDB(order=4, jac_quality=3)) isa ProbNumDiffEq.ProbODESolution
+    end
+    @testset "with jacobian" begin
+        # now with defined jac
+        prob = ProbNumDiffEq.remake_prob_with_jac(prob)
+        @test solve(prob, EK0(order=4)) isa ProbNumDiffEq.ProbODESolution
+        @test solve(prob, EK1(order=4)) isa ProbNumDiffEq.ProbODESolution
+        @test solve(prob, EK1FDB(order=4, jac_quality=1)) isa ProbNumDiffEq.ProbODESolution
+        @test solve(prob, EK1FDB(order=4, jac_quality=2)) isa ProbNumDiffEq.ProbODESolution
+        @test solve(prob, EK1FDB(order=4, jac_quality=3)) isa ProbNumDiffEq.ProbODESolution
+    end
 end
 
 @testset "Callback: Harmonic Oscillator with condition on E=2" begin


### PR DESCRIPTION
Updates the state with information not only on the first, but also on the second derivative! Can be (asymptotically) as cheap as the EK1 when `jac_quality=1` or `jac_quality=2`. But right now, only the more expensive `jac_quality=3` seems really reliable - but it requires an additional jacobian.