### PR TITLE
Adjust the Octavian.jl part a bit to reduce the compilation times

### DIFF
--- a/src/ProbNumDiffEq.jl
+++ b/src/ProbNumDiffEq.jl
@@ -36,8 +36,10 @@ using Tullio
 _matmul!(C, A, B) = mul!(C, A, B)
 _matmul!(C, A, B, a, b) = mul!(C, A, B, a, b)
 # Some special cases
-_matmul!(C::AbstractMatrix, A::AbstractMatrix, B::Diagonal) = (C .= A .* B.diag')
-_matmul!(C::AbstractMatrix, A::Diagonal, B::AbstractMatrix) = (C .= A.diag .* B)
+_matmul!(C::AbstractMatrix{Float64}, A::AbstractMatrix{Float64}, B::Diagonal{Float64}) =
+    (C .= A .* B.diag')
+_matmul!(C::AbstractMatrix{Float64}, A::Diagonal{Float64}, B::AbstractMatrix{Float64}) =
+    (C .= A.diag .* B)
 _matmul!(C::Diagonal{Float64}, A::AbstractMatrix{Float64}, B::AbstractMatrix{Float64}) =
     @tullio C[i, i] = A[i, j] * B[j, i]
 # Use Octavian's matmul! when the types are very specific

--- a/src/ProbNumDiffEq.jl
+++ b/src/ProbNumDiffEq.jl
@@ -32,39 +32,39 @@ using RecursiveArrayTools
 using StaticArrays
 using ForwardDiff
 using Tullio
-import Octavian: matmul!
+# import Octavian: matmul!
 # Define some fallbacks
-const OctavianCompatibleEltypes =
-    Union{Bool,Float16,Float32,Float64,Int16,Int32,Int64,Int8,UInt16,UInt32,UInt64,UInt8}
-_matmul!(
-    C::AbstractVecOrMat{T},
-    A::AbstractVecOrMat{T},
-    B::AbstractVecOrMat{T},
-) where {T<:OctavianCompatibleEltypes} = matmul!(C, A, B)
-_matmul!(
-    C::AbstractVecOrMat{T},
-    A::AbstractVecOrMat{T},
-    B::AbstractVecOrMat{T},
-    a::T,
-    b::T,
-) where {T<:OctavianCompatibleEltypes} = matmul!(C, A, B, a, b)
 _matmul!(C, A, B) = mul!(C, A, B)
 _matmul!(C, A, B, a, b) = mul!(C, A, B, a, b)
-_matmul!(
-    C::AbstractMatrix{T},
-    A::AbstractMatrix{T},
-    B::Diagonal{T},
-) where {T<:OctavianCompatibleEltypes} = (C .= A .* B.diag')
-_matmul!(
-    C::AbstractMatrix{T},
-    A::Diagonal{T},
-    B::AbstractMatrix{T},
-) where {T<:OctavianCompatibleEltypes} = (C .= A.diag .* B)
-_matmul!(
-    C::Diagonal{T},
-    A::AbstractMatrix{T},
-    B::AbstractMatrix{T},
-) where {T<:OctavianCompatibleEltypes} = @tullio C[i, i] = A[i, j] * B[j, i]
+# const OctavianCompatibleEltypes =
+#     Union{Bool,Float16,Float32,Float64,Int16,Int32,Int64,Int8,UInt16,UInt32,UInt64,UInt8}
+# _matmul!(
+#     C::AbstractVecOrMat{T},
+#     A::AbstractVecOrMat{T},
+#     B::AbstractVecOrMat{T},
+# ) where {T<:OctavianCompatibleEltypes} = matmul!(C, A, B)
+# _matmul!(
+#     C::AbstractVecOrMat{T},
+#     A::AbstractVecOrMat{T},
+#     B::AbstractVecOrMat{T},
+#     a::T,
+#     b::T,
+# ) where {T<:OctavianCompatibleEltypes} = matmul!(C, A, B, a, b)
+# _matmul!(
+#     C::AbstractMatrix{T},
+#     A::AbstractMatrix{T},
+#     B::Diagonal{T},
+# ) where {T<:OctavianCompatibleEltypes} = (C .= A .* B.diag')
+# _matmul!(
+#     C::AbstractMatrix{T},
+#     A::Diagonal{T},
+#     B::AbstractMatrix{T},
+# ) where {T<:OctavianCompatibleEltypes} = (C .= A.diag .* B)
+# _matmul!(
+#     C::Diagonal{T},
+#     A::AbstractMatrix{T},
+#     B::AbstractMatrix{T},
+# ) where {T<:OctavianCompatibleEltypes} = @tullio C[i, i] = A[i, j] * B[j, i]
 
 # @reexport using PSDMatrices
 # import PSDMatrices: X_A_Xt

--- a/src/ProbNumDiffEq.jl
+++ b/src/ProbNumDiffEq.jl
@@ -32,39 +32,28 @@ using RecursiveArrayTools
 using StaticArrays
 using ForwardDiff
 using Tullio
-# import Octavian: matmul!
-# Define some fallbacks
+# By default use mul!
 _matmul!(C, A, B) = mul!(C, A, B)
 _matmul!(C, A, B, a, b) = mul!(C, A, B, a, b)
-# const OctavianCompatibleEltypes =
-#     Union{Bool,Float16,Float32,Float64,Int16,Int32,Int64,Int8,UInt16,UInt32,UInt64,UInt8}
-# _matmul!(
-#     C::AbstractVecOrMat{T},
-#     A::AbstractVecOrMat{T},
-#     B::AbstractVecOrMat{T},
-# ) where {T<:OctavianCompatibleEltypes} = matmul!(C, A, B)
-# _matmul!(
-#     C::AbstractVecOrMat{T},
-#     A::AbstractVecOrMat{T},
-#     B::AbstractVecOrMat{T},
-#     a::T,
-#     b::T,
-# ) where {T<:OctavianCompatibleEltypes} = matmul!(C, A, B, a, b)
-# _matmul!(
-#     C::AbstractMatrix{T},
-#     A::AbstractMatrix{T},
-#     B::Diagonal{T},
-# ) where {T<:OctavianCompatibleEltypes} = (C .= A .* B.diag')
-# _matmul!(
-#     C::AbstractMatrix{T},
-#     A::Diagonal{T},
-#     B::AbstractMatrix{T},
-# ) where {T<:OctavianCompatibleEltypes} = (C .= A.diag .* B)
-# _matmul!(
-#     C::Diagonal{T},
-#     A::AbstractMatrix{T},
-#     B::AbstractMatrix{T},
-# ) where {T<:OctavianCompatibleEltypes} = @tullio C[i, i] = A[i, j] * B[j, i]
+# Some special cases
+_matmul!(C::AbstractMatrix, A::AbstractMatrix, B::Diagonal) = (C .= A .* B.diag')
+_matmul!(C::AbstractMatrix, A::Diagonal, B::AbstractMatrix) = (C .= A.diag .* B)
+_matmul!(C::Diagonal{Float64}, A::AbstractMatrix{Float64}, B::AbstractMatrix{Float64}) =
+    @tullio C[i, i] = A[i, j] * B[j, i]
+# Use Octavian's matmul! when the types are very specific
+import Octavian: matmul!
+_matmul!(
+    C::AbstractVecOrMat{Float64},
+    A::AbstractVecOrMat{Float64},
+    B::AbstractVecOrMat{Float64},
+) = matmul!(C, A, B)
+_matmul!(
+    C::AbstractVecOrMat{Float64},
+    A::AbstractVecOrMat{Float64},
+    B::AbstractVecOrMat{Float64},
+    a::Float64,
+    b::Float64,
+) = matmul!(C, A, B, a, b)
 
 # @reexport using PSDMatrices
 # import PSDMatrices: X_A_Xt

--- a/test/diffusions.jl
+++ b/test/diffusions.jl
@@ -1,4 +1,5 @@
 using Test
+using ProbNumDiffEq
 using OrdinaryDiffEq
 using DiffEqProblemLibrary.ODEProblemLibrary: importodeproblems;
 importodeproblems();


### PR DESCRIPTION
- [x] I should (locally) check the time-to-first-solve and the solver performance after compilation, and then decide which one matters more right now. 

Update:
Octavian.jl does matter (~7.5ms to 5ms), so I'll keep it. But, by specifying only Float64 (when do I use anything else anyways) the compilation times get reduced by ~15 seconds. 