### PR TITLE
Improve the FixedMVDiffusion model

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProbNumDiffEq"
 uuid = "bf3e78b0-7d74-48a5-b855-9609533b56a5"
 authors = ["Nathanael Bosch"]
-version = "0.4.2"
+version = "0.5.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/src/diffusions.jl
+++ b/src/diffusions.jl
@@ -17,7 +17,7 @@ initial_diffusion(diffusionmodel::DynamicMVDiffusion, d, q, Eltype) =
     kron(Diagonal(ones(Eltype, d)), Diagonal(ones(Eltype, q + 1)))
 estimate_local_diffusion(kind::DynamicMVDiffusion, integ) = local_diagonal_diffusion(integ)
 
-Base.@kwdef struct FixedDiffusion{T} <: AbstractStaticDiffusion
+Base.@kwdef struct FixedDiffusion{T<:Number} <: AbstractStaticDiffusion
     initial_diffusion::T = 1.0
     calibrate::Bool = true
 end
@@ -55,10 +55,13 @@ end
 
 Base.@kwdef struct FixedMVDiffusion{T} <: AbstractStaticDiffusion
     initial_diffusion::T = 1.0
+    calibrate::Bool = true
 end
-initial_diffusion(diffusionmodel::FixedMVDiffusion, d, q, Eltype) =
-    diffusionmodel.initial_diffusion .*
-    kron(Diagonal(ones(Eltype, d)), Diagonal(ones(Eltype, q + 1)))
+function initial_diffusion(diffusionmodel::FixedMVDiffusion, d, q, Eltype)
+    initdiff = diffusionmodel.initial_diffusion
+    @assert initdiff isa Number || length(initdiff) == d
+    return kron(Diagonal(initdiff .* ones(Eltype, d)), Diagonal(ones(Eltype, q + 1)))
+end
 estimate_local_diffusion(kind::FixedMVDiffusion, integ) = local_diagonal_diffusion(integ)
 function estimate_global_diffusion(kind::FixedMVDiffusion, integ)
     @unpack q, measurement = integ.cache

--- a/test/diffusions.jl
+++ b/test/diffusions.jl
@@ -32,7 +32,7 @@ import DiffEqProblemLibrary.ODEProblemLibrary:
         @test sol.u[end] ≈ true_sol.(sol.t)[end]
     end
 
-    @testset "Time-Fixed Diffusion - uncalibrated" begin
+    @testset "Time-Fixed Diffusion - uncalibrated and with custom initial value" begin
         sol = solve(
             prob,
             EK0(diffusionmodel=FixedDiffusion(1e3, false), smooth=false),
@@ -58,6 +58,19 @@ import DiffEqProblemLibrary.ODEProblemLibrary:
         sol = solve(
             prob,
             EK0(diffusionmodel=FixedMVDiffusion(), smooth=false),
+            dense=false,
+            adaptive=false,
+            dt=1e-4,
+        )
+        @test sol.u[end] ≈ true_sol.(sol.t)[end]
+    end
+
+    @testset "Time-Fixed Diagonal Diffusion - uncalibrated and with custom values" begin
+        d = length(prob.u0)
+        initial_diffusion = 1 .+ rand(d)
+        sol = solve(
+            prob,
+            EK0(diffusionmodel=FixedMVDiffusion(initial_diffusion, false), smooth=false),
             dense=false,
             adaptive=false,
             dt=1e-4,


### PR DESCRIPTION
It now allows for either a scalar or vector-valued initial diffusion, and has an option to set `calibrate=false`.