### PR TITLE
Remove the `prior` field from the ODE filter algorithms

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProbNumDiffEq"
 uuid = "bf3e78b0-7d74-48a5-b855-9609533b56a5"
 authors = ["Nathanael Bosch"]
-version = "0.5.5"
+version = "0.5.6"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -5,11 +5,11 @@ abstract type GaussianODEFilter <: OrdinaryDiffEq.OrdinaryDiffEqAdaptiveAlgorith
 abstract type AbstractEK <: GaussianODEFilter end
 
 """
-    EK0(; prior=:ibm, order=3, diffusionmodel=DynamicDiffusion(), smooth=true)
+    EK0(; order=3, diffusionmodel=DynamicDiffusion(), smooth=true)
 
 **Gaussian ODE filtering with zeroth order extended Kalman filtering.**
 
-Currently, only the integrated Brownian motion prior `:ibm` is supported.
+All solvers use an integrated Brownian motion prior of order `order`.
 For the diffusionmodel, chose one of
 `[DynamicDiffusion(), DynamicMVDiffusion(), FixedDiffusion(), FixedMVDiffusion()]`.
 
@@ -21,7 +21,6 @@ See also: [`EK1`](@ref)
 - M. Schober, S. Särkkä, and P. Hennig: **A Probabilistic Model for the Numerical Solution of Initial Value Problems** (2018)
 """
 Base.@kwdef struct EK0{DT,IT} <: AbstractEK
-    prior::Symbol = :ibm
     order::Int = 3
     diffusionmodel::DT = DynamicDiffusion()
     smooth::Bool = true
@@ -29,11 +28,11 @@ Base.@kwdef struct EK0{DT,IT} <: AbstractEK
 end
 
 """
-    EK1(; prior=:ibm, order=3, diffusionmodel=DynamicDiffusion(), smooth=true)
+    EK1(; order=3, diffusionmodel=DynamicDiffusion(), smooth=true)
 
 **Gaussian ODE filtering with first order extended Kalman filtering.**
 
-Currently, only the integrated Brownian motion prior `:ibm` is supported.
+All solvers use an integrated Brownian motion prior of order `order`.
 For the diffusionmodel, chose one of
 `[DynamicDiffusion(), DynamicMVDiffusion(), FixedDiffusion(), FixedMVDiffusion()]`.
 
@@ -44,14 +43,12 @@ See also: [`EK0`](@ref)
 - F. Tronarp, H. Kersting, S. Särkkä, and P. Hennig: **Probabilistic Solutions To Ordinary Differential Equations As Non-Linear Bayesian Filtering: A New Perspective** (2019)
 """
 struct EK1{CS,AD,DiffType,DT,IT} <: AbstractEK
-    prior::Symbol
     order::Int
     diffusionmodel::DT
     smooth::Bool
     initialization::IT
 end
 EK1(;
-    prior=:ibm,
     order=3,
     diffusionmodel=DynamicDiffusion(),
     smooth=true,
@@ -60,7 +57,6 @@ EK1(;
     autodiff=true,
     diff_type=Val{:forward},
 ) = EK1{chunk_size,autodiff,diff_type,typeof(diffusionmodel),typeof(initialization)}(
-    prior,
     order,
     diffusionmodel,
     smooth,
@@ -68,7 +64,6 @@ EK1(;
 )
 
 Base.@kwdef struct EK1FDB{DT,IT} <: AbstractEK
-    prior::Symbol = :ibm
     order::Int = 3
     diffusionmodel::DT = DynamicDiffusion()
     smooth::Bool = true

--- a/src/caches.jl
+++ b/src/caches.jl
@@ -123,7 +123,6 @@ function OrdinaryDiffEq.alg_cache(
     SolProj = f isa DynamicalODEFunction ? [Proj(1); Proj(0)] : Proj(0)
 
     # Prior dynamics
-    @assert alg.prior == :ibm "Only the ibm prior is implemented so far"
     P, PI = init_preconditioner(d, q, uElType)
 
     A, Q = ibm(d, q, uElType)


### PR DESCRIPTION
They only had a single `:ibm` option anyways. If other priors will be implemented in the future, chances are they would follow a different design than just a symbol field in the solvers. 