### PR TITLE
Make the ManifoldUpdate much more efficient

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -52,6 +52,11 @@ Update the state to satisfy a zero residual function via iterated extended Kalma
 performs an iterated extended Kalman filter update to keep the residual measurement to be
 zero. Additional arguments and keyword arguments for the `DiscreteCallback` can be passed.
 
+The residual function should be `residual(u::AbstractVector)::AbstractVector`, that is
+_it should not be in-place_ (whereas DiffEqCallback.jl's `ManifoldProjection`) is.
+If you encounter `SingularException`s, make sure that the residual function is such that
+its Jacobian has full rank.
+
 # Additional keyword arguments
 - `maxiters::Int`: Maximum number of IEKF iterations.
   Setting this to 1 results in a single standard EKF update.


### PR DESCRIPTION
Previously, each IEKF iteration allocated a bunch of new matrices, which hurt the performance: A solve with a ManifoldUpdate callback took ~15ms for a system that is solved in ~1.5ms without callback.

Now the number of fresh allocations is greatly reduced and the solve with callback takes only ~2.7ms.

This could still be improved, e.g. by using some of the already existing cache matrices or by requiring that the residual function is in-place, or even that it has to have a specific output shape. 

EDIT: The issue with having the same dimensionality with the residual function as the ODE itself is that the measurement covariance becomes singular. Right now I'm not sure how to best solve this.