### PR TITLE
More robust tmp_cache dispatch

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -11,7 +11,7 @@ OrdinaryDiffEq.standardtag(::EK1{CS,AD,DiffType,ST}) where {CS,AD,DiffType,ST} =
 OrdinaryDiffEq.concrete_jac(::AbstractEK) = nothing
 OrdinaryDiffEq.concrete_jac(::EK1{CS,AD,DiffType,ST,CJ}) where {CS,AD,DiffType,ST,CJ} = CJ
 
-@inline DiffEqBase.get_tmp_cache(integ, alg::EK1, cache::AbstractODEFilterCache) =
+@inline DiffEqBase.get_tmp_cache(integ, alg::AbstractEK, cache::AbstractODEFilterCache) =
     (cache.tmp, cache.atmp)
 OrdinaryDiffEq.get_chunksize(::EK1{CS}) where {CS} = Val(CS)
 OrdinaryDiffEq.isfsal(::AbstractEK) = false


### PR DESCRIPTION
EKCache is the only AbstractODEFilterCache, and so it's safe (at least for now) to extend this function to the other algorithms. The other algorithms were fine because they were using a fallback that has been eliminated by https://github.com/SciML/OrdinaryDiffEq.jl/pull/1753. It would be good to get this patch in so that the ambiguity fix PR can be fully checked.