### PR TITLE
Build a cache inside the ODE solution so make interpolation easier

### DIFF
--- a/src/integrator_utils.jl
+++ b/src/integrator_utils.jl
@@ -122,7 +122,6 @@ function smooth_solution!(integ)
         _gaussian_mul!(integ.sol.pu[i], integ.cache.SolProj, x[i])
         integ.sol.u[i][:] .= integ.sol.pu[i].μ
     end
-    integ.sol.interp = set_smooth(integ.sol.interp)
     return nothing
 end
 

--- a/src/perform_step.jl
+++ b/src/perform_step.jl
@@ -104,7 +104,7 @@ function OrdinaryDiffEq.perform_step!(integ, cache::EKCache, repeat_step=false)
     return nothing
 end
 
-function make_transition_matrices!(cache::Union{EKCache,GaussianODEFilterPosterior}, dt)
+function make_transition_matrices!(cache::EKCache, dt)
     @unpack A, Q, Ah, Qh, P, PI = cache
     make_preconditioners!(cache, dt)
     @. Ah .= PI.diag .* A .* P.diag'

--- a/src/preconditioning.jl
+++ b/src/preconditioning.jl
@@ -11,13 +11,6 @@ function make_preconditioners!(cache::AbstractODEFilterCache, dt)
     make_preconditioner_inv!(PI, dt, d, q)
     return nothing
 end
-function make_preconditioners!(post::GaussianODEFilterPosterior, dt)
-    @unpack P, PI, d, q = post
-    make_preconditioner!(P, dt, d, q)
-    # make_preconditioner_inv!(PI, dt, d, q)
-    PI.diag .= 1 ./ P.diag
-    return nothing
-end
 
 @fastmath @inbounds function make_preconditioner!(P, h, d, q)
     val = factorial(q) / h^(q + 1 / 2)

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -160,11 +160,13 @@ mutable struct MeanProbODESolution{
     probsol::PSolType
 end
 MeanProbODESolution{T,N}(
-    u, u_analytic, errs, t, k, prob, alg, interp, cache, dense, tsl, destats, retcode, probsol,
+    u, u_analytic, errs, t, k, prob, alg, interp, cache, dense, tsl, destats, retcode,
+    probsol,
 ) where {T,N} = MeanProbODESolution{
     T,N,typeof(u),typeof(u_analytic),typeof(errs),typeof(t),typeof(k),typeof(prob),
     typeof(alg),typeof(interp),typeof(cache),typeof(destats),typeof(probsol)}(
-    u, u_analytic, errs, t, k, prob, alg, interp, cache, dense, tsl, destats, retcode, probsol,
+    u, u_analytic, errs, t, k, prob, alg, interp, cache, dense, tsl, destats, retcode,
+    probsol,
 )
 
 DiffEqBase.build_solution(sol::MeanProbODESolution{T,N}, u_analytic, errors) where {T,N} =
@@ -178,8 +180,8 @@ function mean(sol::ProbODESolution{T,N}) where {T,N}
         typeof(sol.k),typeof(sol.prob),typeof(sol.alg),typeof(sol.interp),typeof(sol.cache),
         typeof(sol.destats),typeof(sol),
     }(
-        sol.u, sol.u_analytic, sol.errors, sol.t, sol.k, sol.prob, sol.alg, sol.interp, sol.cache,
-        sol.dense, sol.tslocation, sol.destats, sol.retcode, sol,
+        sol.u, sol.u_analytic, sol.errors, sol.t, sol.k, sol.prob, sol.alg, sol.interp,
+        sol.cache, sol.dense, sol.tslocation, sol.destats, sol.retcode, sol,
     )
 end
 (sol::MeanProbODESolution)(t::Real, args...) = mean(sol.probsol(t, args...))

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -64,6 +64,25 @@ function DiffEqBase.build_solution(
     dense=true,
     kwargs...,
 )
+    # By making an actual cache, interpolation can be written very closely to the solver
+    cache = OrdinaryDiffEq.alg_cache(
+        alg,
+        prob.u0,
+        recursivecopy(prob.u0),
+        recursive_unitless_eltype(prob.u0),
+        recursive_unitless_bottom_eltype(prob.u0),
+        eltype(t),
+        recursivecopy(prob.u0),
+        recursivecopy(prob.u0),
+        prob.f,
+        t,
+        eltype(prob.tspan)(1),
+        nothing,
+        prob.p,
+        true,
+        Val(isinplace(prob)),
+    )
+
     T = eltype(eltype(u))
     N = length((size(prob.u0)..., length(u)))
 

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -142,7 +142,7 @@ Since it is the mean and does never return Gaussians, it can basically be treate
 were a classic ODE solution and is well-compatible with e.g. DiffEqDevtools.jl.
 """
 mutable struct MeanProbODESolution{
-    T,N,uType,uType2,DType,tType,rateType,P,A,IType,DE,PSolType,
+    T,N,uType,uType2,DType,tType,rateType,P,A,IType,CType,DE,PSolType,
 } <: DiffEqBase.AbstractODESolution{T,N,uType}
     u::uType
     u_analytic::uType2
@@ -152,6 +152,7 @@ mutable struct MeanProbODESolution{
     prob::P
     alg::A
     interp::IType
+    cache::CType
     dense::Bool
     tslocation::Int
     destats::DE
@@ -159,11 +160,11 @@ mutable struct MeanProbODESolution{
     probsol::PSolType
 end
 MeanProbODESolution{T,N}(
-    u, u_analytic, errs, t, k, prob, alg, interp, dense, tsl, destats, retcode, probsol,
+    u, u_analytic, errs, t, k, prob, alg, interp, cache, dense, tsl, destats, retcode, probsol,
 ) where {T,N} = MeanProbODESolution{
     T,N,typeof(u),typeof(u_analytic),typeof(errs),typeof(t),typeof(k),typeof(prob),
-    typeof(alg),typeof(interp),typeof(destats),typeof(probsol)}(
-    u, u_analytic, errs, t, k, prob, alg, interp, dense, tsl, destats, retcode, probsol,
+    typeof(alg),typeof(interp),typeof(cache),typeof(destats),typeof(probsol)}(
+    u, u_analytic, errs, t, k, prob, alg, interp, cache, dense, tsl, destats, retcode, probsol,
 )
 
 DiffEqBase.build_solution(sol::MeanProbODESolution{T,N}, u_analytic, errors) where {T,N} =
@@ -174,10 +175,10 @@ DiffEqBase.build_solution(sol::MeanProbODESolution{T,N}, u_analytic, errors) whe
 function mean(sol::ProbODESolution{T,N}) where {T,N}
     return MeanProbODESolution{
         T,N,typeof(sol.u),typeof(sol.u_analytic),typeof(sol.errors),typeof(sol.t),
-        typeof(sol.k),typeof(sol.prob),typeof(sol.alg),typeof(sol.interp),
+        typeof(sol.k),typeof(sol.prob),typeof(sol.alg),typeof(sol.interp),typeof(sol.cache),
         typeof(sol.destats),typeof(sol),
     }(
-        sol.u, sol.u_analytic, sol.errors, sol.t, sol.k, sol.prob, sol.alg, sol.interp,
+        sol.u, sol.u_analytic, sol.errors, sol.t, sol.k, sol.prob, sol.alg, sol.interp, sol.cache,
         sol.dense, sol.tslocation, sol.destats, sol.retcode, sol,
     )
 end

--- a/src/solution_sampling.jl
+++ b/src/solution_sampling.jl
@@ -22,7 +22,7 @@ function sample(sol::ProbODESolution, n::Int=1)
     sample_path = sample_states(sol, n)
     return sample_path[:, 1:q+1:d*(q+1), :]
 end
-function sample_states(ts, xs, diffusions, difftimes, cache, n::Int=1; )
+function sample_states(ts, xs, diffusions, difftimes, cache, n::Int=1)
     @assert length(diffusions) + 1 == length(difftimes)
 
     @unpack A, Q, d, q = cache
@@ -64,7 +64,15 @@ function dense_sample_states(sol::ProbODESolution, n::Int=1; density=1000)
     @assert sol.alg.smooth "sampling not implemented for non-smoothed posteriors"
     times = range(sol.t[1], sol.t[end], length=density)
     states = StructArray([
-        interpolate(t, sol.t, sol.x_filt, sol.x_smooth, sol.diffusions, sol.cache; smoothed=sol.alg.smooth)
+        interpolate(
+            t,
+            sol.t,
+            sol.x_filt,
+            sol.x_smooth,
+            sol.diffusions,
+            sol.cache;
+            smoothed=sol.alg.smooth,
+        )
         for t in times
     ])
 

--- a/src/solution_sampling.jl
+++ b/src/solution_sampling.jl
@@ -14,18 +14,18 @@ function _rand(x::SRGaussian, n::Integer=1)
 end
 
 function sample_states(sol::ProbODESolution, n::Int=1)
-    @assert sol.interp.smooth "sampling not implemented for non-smoothed posteriors"
-    return sample_states(sol.t, sol.x_filt, sol.diffusions, sol.t, sol.interp, n)
+    @assert sol.alg.smooth "sampling not implemented for non-smoothed posteriors"
+    return sample_states(sol.t, sol.x_filt, sol.diffusions, sol.t, sol.cache, n)
 end
 function sample(sol::ProbODESolution, n::Int=1)
-    d, q = sol.interp.d, sol.interp.q
+    @unpack d, q = sol.cache
     sample_path = sample_states(sol, n)
     return sample_path[:, 1:q+1:d*(q+1), :]
 end
-function sample_states(ts, xs, diffusions, difftimes, posterior, n::Int=1)
+function sample_states(ts, xs, diffusions, difftimes, cache, n::Int=1; )
     @assert length(diffusions) + 1 == length(difftimes)
 
-    @unpack A, Q, d, q = posterior
+    @unpack A, Q, d, q = cache
     D = d * (q + 1)
 
     x = xs[end]
@@ -42,8 +42,8 @@ function sample_states(ts, xs, diffusions, difftimes, posterior, n::Int=1)
         i_diffusion = sum(difftimes .<= ts[i])
         diffusion = diffusions[i_diffusion]
 
-        make_transition_matrices!(posterior, dt)
-        Ah, Qh = posterior.Ah, posterior.Qh
+        make_transition_matrices!(cache, dt)
+        Ah, Qh = cache.Ah, cache.Qh
         Qh = apply_diffusion(Q, diffusion)
 
         for j in 1:n
@@ -61,17 +61,17 @@ function sample_states(ts, xs, diffusions, difftimes, posterior, n::Int=1)
     return sample_path
 end
 function dense_sample_states(sol::ProbODESolution, n::Int=1; density=1000)
-    @assert sol.interp.smooth "sampling not implemented for non-smoothed posteriors"
+    @assert sol.alg.smooth "sampling not implemented for non-smoothed posteriors"
     times = range(sol.t[1], sol.t[end], length=density)
     states = StructArray([
-        sol.interp(t, sol.t, sol.x_filt, sol.x_smooth, sol.diffusions; smoothed=false)
+        interpolate(t, sol.t, sol.x_filt, sol.x_smooth, sol.diffusions, sol.cache; smoothed=sol.alg.smooth)
         for t in times
     ])
 
-    return sample_states(times, states, sol.diffusions, sol.t, sol.interp, n), times
+    return sample_states(times, states, sol.diffusions, sol.t, sol.cache, n), times
 end
 function dense_sample(sol::ProbODESolution, n::Int=1; density=1000)
     samples, times = dense_sample_states(sol, n; density=density)
-    d, q = sol.interp.d, sol.interp.q
+    @unpack d, q = sol.cache
     return samples[:, 1:q+1:d*(q+1), :], times
 end

--- a/test/solution.jl
+++ b/test/solution.jl
@@ -84,14 +84,14 @@ using ODEProblemLibrary: prob_ode_lotkavolterra
 
         m, n, o = size(samples)
         @test m == length(sol)
-        @test n == length(sol.u[1]) * (sol.interp.q + 1)
+        @test n == length(sol.u[1]) * (sol.cache.q + 1)
         @test o == n_samples
 
         # Dense sampling
         dense_samples, dense_times = ProbNumDiffEq.dense_sample_states(sol, n_samples)
         m, n, o = size(dense_samples)
         @test m == length(dense_times)
-        @test n == length(sol.u[1]) * (sol.interp.q + 1)
+        @test n == length(sol.u[1]) * (sol.cache.q + 1)
         @test o == n_samples
     end
 


### PR DESCRIPTION
Previously I had a `GaussianODEFilterPosterior` object that holds information about the prior etc. Now, I just use the `cache` object that the solver constructs! Might lead to more allocated objects (and ideally there would be only one `cache`, shared between the solver and the solution object), but code got simpler :)