### PR TITLE
Split the "solver" page in the documentation to make it easier to see where to find what

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,7 +12,12 @@ makedocs(
             "Second Order ODEs and Energy Preservation" => "dynamical_odes.md"
             "Differential Algebraic Equations" => "dae.md"
         ],
-        "Solvers and Options" => "solvers.md",
+        "Solvers and Options" => [
+            "solvers.md",
+            "diffusions.md",
+            "initialization.md",
+            "priors.md",
+        ],
         "Benchmarks" => [
             "Multi-Language Wrapper Benchmark" => "benchmarks/multi-language-wrappers.md",
             "Non-stiff ODE: Lotka-Volterra" => "benchmarks/lotkavolterra.md",

--- a/docs/src/diffusions.md
+++ b/docs/src/diffusions.md
@@ -1,0 +1,16 @@
+# Diffusion models and calibration
+
+In a nutshell:
+"Dynamic" diffusion models allow the diffusion to change in-between each solver step and are recommended in combination with adaptive step-sizes.
+"Fixed" diffusion models keep the diffusion constant and can be helpful in fixed-step settings or for debugging by reducing the complexity of the models.
+
+For more information on the influence of diffusions, check out
+
+  - N. Bosch, P. Hennig, F. Tronarp: **Calibrated Adaptive Probabilistic ODE Solvers** (2021)
+
+```@docs
+DynamicDiffusion
+FixedDiffusion
+DynamicMVDiffusion
+FixedMVDiffusion
+```

--- a/docs/src/diffusions.md
+++ b/docs/src/diffusions.md
@@ -1,12 +1,50 @@
 # Diffusion models and calibration
 
-In a nutshell:
-"Dynamic" diffusion models allow the diffusion to change in-between each solver step and are recommended in combination with adaptive step-sizes.
-"Fixed" diffusion models keep the diffusion constant and can be helpful in fixed-step settings or for debugging by reducing the complexity of the models.
+The notion of "diffusion" and "calibration" relates to the _prior_ part of the model.
 
-For more information on the influence of diffusions, check out
+## Background: The prior
 
-  - N. Bosch, P. Hennig, F. Tronarp: **Calibrated Adaptive Probabilistic ODE Solvers** (2021)
+We model the ODE solution ``y(t)`` with a Gauss--Markov prior.
+More precisely, let
+```math
+\begin{aligned}
+Y(t) = \left[ Y^{(0)}(t), Y^{(1)}(t), \dots Y^{(q)}(t) \right],
+\end{aligned}
+```
+be the solution to the SDE
+```math
+\begin{aligned}
+\text{d} Y^{(i)}(t) &= Y^{(i+1)}(t) \ \text{d}t, \qquad i = 0, \dots, q-1 \\
+\text{d} Y^{(q)}(t) &= A Y(t) \ \text{d}t + \textcolor{royalblue}{\Gamma} \ \text{d}W(t).
+\end{aligned}
+```
+Then ``Y^{(i)}(t)`` models the ``i``-th derivative of ``y(t)``.
+**In this section, we consider choices relating to the _"diffusion"_ ``\textcolor{royalblue}{\Gamma}``.**
+
+
+## Diffusion and calibration
+
+We call ``\textcolor{royalblue}{\Gamma}`` the _"diffusion"_ parameter.
+Since it is typically not known we need to estimate it; this is called _"calibration"_.
+
+There are a few different choices for how to model and estimate ``\textcolor{royalblue}{\Gamma}``:
+- [`FixedDiffusion`](@ref) assumes an isotropic, time-fixed ``\textcolor{royalblue}{\Gamma} = \sigma \cdot I_d``,
+- [`DynamicDiffusion`](@ref) assumes an isotropic, time-varying ``\textcolor{royalblue}{\Gamma}(t) = \sigma(t) \cdot I_d``,
+- [`FixedMVDiffusion`](@ref) assumes a diagonal, time-fixed ``\textcolor{royalblue}{\Gamma} = \operatorname{diag}(\sigma_1, \dots, \sigma_d)``,
+- [`DynamicMVDiffusion`](@ref) assumes a diagonal, time-varying ``\textcolor{royalblue}{\Gamma}(t) = \operatorname{diag}(\sigma_1(t), \dots, \sigma_d(t))``.
+
+Or more compactly:
+
+|              | Isotropic:                   | Diagonal (only for the `EK0`(@ref)) |
+|--------------|----------------------------|-------------------------------------|
+| Time-varying | [`DynamicDiffusion`](@ref) | [`DynamicMVDiffusion`](@ref)        |
+| Time-fixed   | [`FixedDiffusion`](@ref)   | [`FixedMVDiffusion`](@ref)          |
+
+
+For more details on diffusions and calibration, check out this paper [[1]](@ref diffusionrefs).
+
+
+## API
 
 ```@docs
 DynamicDiffusion
@@ -14,3 +52,8 @@ FixedDiffusion
 DynamicMVDiffusion
 FixedMVDiffusion
 ```
+
+
+## [References](@id diffusionrefs)
+
+[1] N. Bosch, P. Hennig, F. Tronarp: **Calibrated Adaptive Probabilistic ODE Solvers** (2021) ([link](http://proceedings.mlr.press/v130/bosch21a.html))

--- a/docs/src/diffusions.md
+++ b/docs/src/diffusions.md
@@ -14,25 +14,27 @@ Y(t) = \left[ Y^{(0)}(t), Y^{(1)}(t), \dots Y^{(q)}(t) \right],
 be the solution to the SDE
 ```math
 \begin{aligned}
-\text{d} Y^{(i)}(t) &= Y^{(i+1)}(t) \ \text{d}t, \qquad i = 0, \dots, q-1 \\
-\text{d} Y^{(q)}(t) &= \textcolor{forestgreen}{A} Y(t) \ \text{d}t + \textcolor{royalblue}{\Gamma} \ \text{d}W(t).
+\text{d} Y^{(i)}(t) &= Y^{(i+1)}(t) \ \text{d}t, \qquad i = 0, \dots, q-1, \\
+\text{d} Y^{(q)}(t) &= \textcolor{#389826}{A} Y(t) \ \text{d}t + \textcolor{#4063D8}{\Gamma} \ \text{d}W(t), \\
+Y(0) &\sim \textcolor{purple}{ \mathcal{N} \left( \mu_0, \Sigma_0 \right) }.
 \end{aligned}
 ```
 Then ``Y^{(i)}(t)`` models the ``i``-th derivative of ``y(t)``.
-**In this section, we consider choices relating to the _"diffusion"_ ``\textcolor{royalblue}{\Gamma}``.**
-If you're more interested in the _drift matrix_ ``\textcolor{forestgreen}{A}``, check out the [Priors](@ref) section.
+**In this section, we consider choices relating to the _"diffusion"_ ``\textcolor{#4063D8}{\Gamma}``.**
+If you're more interested in the _drift matrix_ ``\textcolor{#389826}{A}`` check out the [Priors](@ref) section,
+and for info on the initial distribution ``\textcolor{purple}{ \mathcal{N} \left( \mu_0, \Sigma_0 \right) }`` check out the [Initialization](@ref) section.
 
 
 ## Diffusion and calibration
 
-We call ``\textcolor{royalblue}{\Gamma}`` the _"diffusion"_ parameter.
+We call ``\textcolor{#4063D8}{\Gamma}`` the _"diffusion"_ parameter.
 Since it is typically not known we need to estimate it; this is called _"calibration"_.
 
-There are a few different choices for how to model and estimate ``\textcolor{royalblue}{\Gamma}``:
-- [`FixedDiffusion`](@ref) assumes an isotropic, time-fixed ``\textcolor{royalblue}{\Gamma} = \sigma \cdot I_d``,
-- [`DynamicDiffusion`](@ref) assumes an isotropic, time-varying ``\textcolor{royalblue}{\Gamma}(t) = \sigma(t) \cdot I_d`` (**recommended**),
-- [`FixedMVDiffusion`](@ref) assumes a diagonal, time-fixed ``\textcolor{royalblue}{\Gamma} = \operatorname{diag}(\sigma_1, \dots, \sigma_d)``,
-- [`DynamicMVDiffusion`](@ref) assumes a diagonal, time-varying ``\textcolor{royalblue}{\Gamma}(t) = \operatorname{diag}(\sigma_1(t), \dots, \sigma_d(t))``.
+There are a few different choices for how to model and estimate ``\textcolor{#4063D8}{\Gamma}``:
+- [`FixedDiffusion`](@ref) assumes an isotropic, time-fixed ``\textcolor{#4063D8}{\Gamma} = \sigma \cdot I_d``,
+- [`DynamicDiffusion`](@ref) assumes an isotropic, time-varying ``\textcolor{#4063D8}{\Gamma}(t) = \sigma(t) \cdot I_d`` (**recommended**),
+- [`FixedMVDiffusion`](@ref) assumes a diagonal, time-fixed ``\textcolor{#4063D8}{\Gamma} = \operatorname{diag}(\sigma_1, \dots, \sigma_d)``,
+- [`DynamicMVDiffusion`](@ref) assumes a diagonal, time-varying ``\textcolor{#4063D8}{\Gamma}(t) = \operatorname{diag}(\sigma_1(t), \dots, \sigma_d(t))``.
 
 Or more compactly:
 

--- a/docs/src/diffusions.md
+++ b/docs/src/diffusions.md
@@ -20,7 +20,7 @@ be the solution to the SDE
 ```
 Then ``Y^{(i)}(t)`` models the ``i``-th derivative of ``y(t)``.
 **In this section, we consider choices relating to the _"diffusion"_ ``\textcolor{royalblue}{\Gamma}``.**
-If you're more interested in the _drift matrix_``\textcolor{forestgreen}{A}``, check out the [Priors](@ref) section.
+If you're more interested in the _drift matrix_ ``\textcolor{forestgreen}{A}``, check out the [Priors](@ref) section.
 
 
 ## Diffusion and calibration
@@ -30,16 +30,16 @@ Since it is typically not known we need to estimate it; this is called _"calibra
 
 There are a few different choices for how to model and estimate ``\textcolor{royalblue}{\Gamma}``:
 - [`FixedDiffusion`](@ref) assumes an isotropic, time-fixed ``\textcolor{royalblue}{\Gamma} = \sigma \cdot I_d``,
-- [`DynamicDiffusion`](@ref) assumes an isotropic, time-varying ``\textcolor{royalblue}{\Gamma}(t) = \sigma(t) \cdot I_d``,
+- [`DynamicDiffusion`](@ref) assumes an isotropic, time-varying ``\textcolor{royalblue}{\Gamma}(t) = \sigma(t) \cdot I_d`` (**recommended**),
 - [`FixedMVDiffusion`](@ref) assumes a diagonal, time-fixed ``\textcolor{royalblue}{\Gamma} = \operatorname{diag}(\sigma_1, \dots, \sigma_d)``,
 - [`DynamicMVDiffusion`](@ref) assumes a diagonal, time-varying ``\textcolor{royalblue}{\Gamma}(t) = \operatorname{diag}(\sigma_1(t), \dots, \sigma_d(t))``.
 
 Or more compactly:
 
-|              | Isotropic:                   | Diagonal (only for the `EK0`(@ref)) |
-|--------------|----------------------------|-------------------------------------|
-| Time-varying | [`DynamicDiffusion`](@ref) | [`DynamicMVDiffusion`](@ref)        |
-| Time-fixed   | [`FixedDiffusion`](@ref)   | [`FixedMVDiffusion`](@ref)          |
+|              | Isotropic:                 | Diagonal (only for the [`EK0`](@ref)) |
+|--------------|----------------------------|---------------------------------------|
+| Time-varying | [`DynamicDiffusion`](@ref) | [`DynamicMVDiffusion`](@ref)          |
+| Time-fixed   | [`FixedDiffusion`](@ref)   | [`FixedMVDiffusion`](@ref)            |
 
 
 For more details on diffusions and calibration, check out this paper [[1]](@ref diffusionrefs).

--- a/docs/src/diffusions.md
+++ b/docs/src/diffusions.md
@@ -15,11 +15,12 @@ be the solution to the SDE
 ```math
 \begin{aligned}
 \text{d} Y^{(i)}(t) &= Y^{(i+1)}(t) \ \text{d}t, \qquad i = 0, \dots, q-1 \\
-\text{d} Y^{(q)}(t) &= A Y(t) \ \text{d}t + \textcolor{royalblue}{\Gamma} \ \text{d}W(t).
+\text{d} Y^{(q)}(t) &= \textcolor{forestgreen}{A} Y(t) \ \text{d}t + \textcolor{royalblue}{\Gamma} \ \text{d}W(t).
 \end{aligned}
 ```
 Then ``Y^{(i)}(t)`` models the ``i``-th derivative of ``y(t)``.
 **In this section, we consider choices relating to the _"diffusion"_ ``\textcolor{royalblue}{\Gamma}``.**
+If you're more interested in the _drift matrix_``\textcolor{forestgreen}{A}``, check out the [Priors](@ref) section.
 
 
 ## Diffusion and calibration

--- a/docs/src/initialization.md
+++ b/docs/src/initialization.md
@@ -1,0 +1,6 @@
+# Initialization
+
+```@docs
+TaylorModeInit
+ClassicSolverInit
+```

--- a/docs/src/initialization.md
+++ b/docs/src/initialization.md
@@ -1,6 +1,71 @@
 # Initialization
 
+The notion of "initialization" relates to the _prior_ part of the model.
+
+
+## Background: The prior
+
+We model the ODE solution ``y(t)`` with a Gauss--Markov prior.
+More precisely, let
+```math
+\begin{aligned}
+Y(t) = \left[ Y^{(0)}(t), Y^{(1)}(t), \dots Y^{(q)}(t) \right],
+\end{aligned}
+```
+be the solution to the SDE
+```math
+\begin{aligned}
+\text{d} Y^{(i)}(t) &= Y^{(i+1)}(t) \ \text{d}t, \qquad i = 0, \dots, q-1 \\
+\text{d} Y^{(q)}(t) &= \textcolor{#389826}{A} Y(t) \ \text{d}t + \textcolor{#4063D8}{\Gamma} \ \text{d}W(t), \\
+Y(0) &\sim \textcolor{#9558B2}{ \mathcal{N} \left( \mu_0, \Sigma_0 \right) }.
+\end{aligned}
+```
+Then ``Y^{(i)}(t)`` models the ``i``-th derivative of ``y(t)``.
+**In this section, we consider the _initial distribution_ ``\textcolor{purple}{ \mathcal{N} \left( \mu_0, \Sigma_0 \right) }``.**
+If you're more interested in the
+_drift matrix_ ``\textcolor{#389826}{A}``
+check out the [Priors](@ref) section,
+and for more info on
+the _diffusion_ ``\textcolor{#4063D8}{\Gamma}``
+check out the
+[Diffusion models and calibration](@ref) section.
+
+
+## Setting the initial distribution
+
+Let's assume an initial value problem of the form
+```math
+\begin{aligned}
+\dot{y}(t) &= f(y(t), t), \qquad [0, T], \\
+y(0) &= y_0.
+\end{aligned}
+```
+It is clear that this contains quite some information for ``Y(0)``:
+The initial value ``y_0`` and the vector field ``f`` imply
+```math
+\begin{aligned}
+Y^{(0)}(0) &= y_0, \\
+Y^{(1)}(0) &= f(y_0, 0).
+\end{aligned}
+```
+And it turns out that we can also compute higher-order derivatives of ``y`` with the chain rule,
+which we can use to initialize ``Y^{(i)}(0)``.
+This, done efficiently with Taylor-mode autodiff by using
+[TaylorIntegration.jl](https://perezhz.github.io/TaylorIntegration.jl/latest/),
+is what [`TaylorModeInit`](@ref) does.
+See also [[1]](@ref initrefs).
+
+**In the vast majority of cases, just stick to the exact Taylor-mode initialization [`TaylorModeInit`](@ref)!**
+
+
+## API
+
 ```@docs
 TaylorModeInit
 ClassicSolverInit
 ```
+
+## [References](@id initrefs)
+
+[1] N. Krämer, P. Hennig: **Stable Implementation of Probabilistic ODE Solvers** (2020) ([link](https://arxiv.org/abs/2012.10106))
+[2] M. Schober, S. Särkkä, and P. Hennig: **A Probabilistic Model for the Numerical Solution of Initial Value Problems** (2018) ([link](https://link.springer.com/article/10.1007/s11222-017-9798-7))

--- a/docs/src/priors.md
+++ b/docs/src/priors.md
@@ -1,0 +1,7 @@
+# Priors
+
+```@docs
+IWP
+IOUP
+Matern
+```

--- a/docs/src/priors.md
+++ b/docs/src/priors.md
@@ -10,13 +10,15 @@ Y(t) = \left[ Y^{(0)}(t), Y^{(1)}(t), \dots Y^{(q)}(t) \right],
 be the solution to the SDE
 ```math
 \begin{aligned}
-\text{d} Y^{(i)}(t) &= Y^{(i+1)}(t) \ \text{d}t, \qquad i = 0, \dots, q-1 \\
-\text{d} Y^{(q)}(t) &= \textcolor{forestgreen}{A} Y(t) \ \text{d}t + \textcolor{royalblue}{\Gamma} \ \text{d}W(t).
+\text{d} Y^{(i)}(t) &= Y^{(i+1)}(t) \ \text{d}t, \qquad i = 0, \dots, q-1, \\
+\text{d} Y^{(q)}(t) &= \textcolor{#389826}{A} Y(t) \ \text{d}t + \textcolor{#4063D8}{\Gamma} \ \text{d}W(t), \\
+Y(0) &\sim \textcolor{purple}{ \mathcal{N} \left( \mu_0, \Sigma_0 \right) }.
 \end{aligned}
 ```
 Then ``Y^{(i)}(t)`` models the ``i``-th derivative of ``y(t)``.
-**In this section, we consider choices relating to the _drift matrix_ ``\textcolor{forestgreen}{A}``.**
-If you're more interested in the _diffusion_ ``\textcolor{royalblue}{\Gamma}``, check out the [Diffusion models and calibration](@ref) section.
+**In this section, we consider choices relating to the _drift matrix_ ``\textcolor{#389826}{A}``.**
+If you're more interested in the _diffusion_ ``\textcolor{#4063D8}{\Gamma}`` check out the [Diffusion models and calibration](@ref) section,
+and for info on the initial distribution ``\textcolor{purple}{ \mathcal{N} \left( \mu_0, \Sigma_0 \right) }`` check out the [Initialization](@ref) section.
 
 **If you're unsure which prior to use, just stick to the integrated Wiener process prior [`IWP`](@ref)!**
 This is also the default choice for all solvers.

--- a/docs/src/priors.md
+++ b/docs/src/priors.md
@@ -1,5 +1,29 @@
 # Priors
 
+We model the ODE solution ``y(t)`` with a Gauss--Markov prior.
+More precisely, let
+```math
+\begin{aligned}
+Y(t) = \left[ Y^{(0)}(t), Y^{(1)}(t), \dots Y^{(q)}(t) \right],
+\end{aligned}
+```
+be the solution to the SDE
+```math
+\begin{aligned}
+\text{d} Y^{(i)}(t) &= Y^{(i+1)}(t) \ \text{d}t, \qquad i = 0, \dots, q-1 \\
+\text{d} Y^{(q)}(t) &= \textcolor{forestgreen}{A} Y(t) \ \text{d}t + \textcolor{royalblue}{\Gamma} \ \text{d}W(t).
+\end{aligned}
+```
+Then ``Y^{(i)}(t)`` models the ``i``-th derivative of ``y(t)``.
+**In this section, we consider choices relating to the _drift matrix_ ``\textcolor{forestgreen}{A}``.**
+If you're more interested in the _diffusion_ ``\textcolor{royalblue}{\Gamma}``, check out the [Diffusion models and calibration](@ref) section.
+
+**If you're unsure which prior to use, just stick to the integrated Wiener process prior [`IWP`](@ref)!**
+This is also the default choice for all solvers.
+The other priors are rather experimental / niche at the time of writing.
+
+## API
+
 ```@docs
 IWP
 IOUP

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -1,12 +1,20 @@
 # Solvers
 
-ProbNumDiffEq.jl provides mainly the following two solvers, both based on extended Kalman filtering and smoothing.
-For the best results we suggest using `EK1`, but note that it relies on the Jacobian of the vector field.
+ProbNumDiffEq.jl provides two solvers: the [`EK1`](@ref) and the [`EK0`](@ref). Both based on extended Kalman filtering and smoothing, but the latter relies on evaluating the Jacobian of the vector field.
+**For the best results, use the [`EK1`](@ref).**
 
-!!! note
-    All solvers are compatible with DAEs in mass-matrix ODE form, and specialize on second-order ODEs.
+All solvers are compatible with DAEs in mass-matrix ODE form.
+They also specialize on second-order ODEs: If the problem is of type [`SecondOrderODEProblem`](https://docs.sciml.ai/DiffEqDocs/stable/solvers/dynamical_solve/), it solves the second-order problem directly; this is more efficient than solving the transformed first-order problem and provides more meaningful posteriors
+[[1]](@ref solversrefs).
+
+
+## API
 
 ```@docs
 EK1
 EK0
 ```
+
+## [References](@id solversrefs)
+
+[1] N. Bosch, F. Tronarp, P. Hennig: **Pick-and-Mix Information Operators for Probabilistic ODE Solvers** (2022) ([link](https://proceedings.mlr.press/v151/bosch22a.html))

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -1,45 +1,12 @@
-# Solvers and Options
+# Solvers
 
 ProbNumDiffEq.jl provides mainly the following two solvers, both based on extended Kalman filtering and smoothing.
 For the best results we suggest using `EK1`, but note that it relies on the Jacobian of the vector field.
 
-## Solvers
-
-All solvers are compatible with DAEs in mass-matrix ODE form, and specialize on second-order ODEs.
+!!! note
+    All solvers are compatible with DAEs in mass-matrix ODE form, and specialize on second-order ODEs.
 
 ```@docs
 EK1
 EK0
-```
-
-## Diffusion models and calibration
-
-In a nutshell:
-"Dynamic" diffusion models allow the diffusion to change in-between each solver step and are recommended in combination with adaptive step-sizes.
-"Fixed" diffusion models keep the diffusion constant and can be helpful in fixed-step settings or for debugging by reducing the complexity of the models.
-
-For more information on the influence of diffusions, check out
-
-  - N. Bosch, P. Hennig, F. Tronarp: **Calibrated Adaptive Probabilistic ODE Solvers** (2021)
-
-```@docs
-DynamicDiffusion
-FixedDiffusion
-DynamicMVDiffusion
-FixedMVDiffusion
-```
-
-## Initialization
-
-```@docs
-TaylorModeInit
-ClassicSolverInit
-```
-
-## Priors
-
-```@docs
-IWP
-IOUP
-Matern
 ```

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -4,7 +4,7 @@ ProbNumDiffEq.jl provides two solvers: the [`EK1`](@ref) and the [`EK0`](@ref). 
 **For the best results, use the [`EK1`](@ref).**
 
 All solvers are compatible with DAEs in mass-matrix ODE form.
-They also specialize on second-order ODEs: If the problem is of type [`SecondOrderODEProblem`](https://docs.sciml.ai/DiffEqDocs/stable/solvers/dynamical_solve/), it solves the second-order problem directly; this is more efficient than solving the transformed first-order problem and provides more meaningful posteriors
+They also specialize on second-order ODEs: If the problem is of type [`SecondOrderODEProblem`](https://docs.sciml.ai/DiffEqDocs/stable/types/dynamical_types/#SciMLBase.SecondOrderODEProblem), it solves the second-order problem directly; this is more efficient than solving the transformed first-order problem and provides more meaningful posteriors
 [[1]](@ref solversrefs).
 
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -21,6 +21,11 @@ abstract type AbstractEK <: OrdinaryDiffEq.OrdinaryDiffEqAdaptiveAlgorithm end
 - `diffusionmodel::ProbNumDiffEq.AbstractDiffusion`: See [Diffusion models and calibration](@ref).
 - `initialization::ProbNumDiffEq.InitializationScheme`: See [Initialization](@ref).
 
+# Examples
+```julia-repl
+julia> solve(prob, EK0())
+```
+
 # [References](@ref references)
 """
 struct EK0{PT,DT,IT} <: AbstractEK
@@ -64,6 +69,11 @@ check out DifferentialEquations.jl's [Extra Options](https://diffeq.sciml.ai/sta
 Right now, we support `autodiff`, `chunk_size`, and `diff_type`.
 In particular, `autodiff=false` can come in handy to use finite differences instead of
 ForwardDiff.jl to compute Jacobians.
+
+# Examples
+```julia-repl
+julia> solve(prob, EK1())
+```
 
 # [References](@ref references)
 """

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -14,10 +14,10 @@ abstract type AbstractEK <: OrdinaryDiffEq.OrdinaryDiffEqAdaptiveAlgorithm end
 
 # Arguments
 - `order::Integer`: Order of the integrated Wiener process (IWP) prior.
+- `smooth::Bool`: Turn smoothing on/off; smoothing is required for dense output.
 - `prior::AbstractODEFilterPrior`: Prior to be used by the ODE filter.
    By default, uses a 3-times integrated Wiener process prior `IWP(3)`.
    See also: [Priors](@ref).
-- `smooth::Bool`: Turn smoothing on/off; smoothing is required for dense output.
 - `diffusionmodel::ProbNumDiffEq.AbstractDiffusion`: See [Diffusion models and calibration](@ref).
 - `initialization::ProbNumDiffEq.InitializationScheme`: See [Initialization](@ref).
 
@@ -57,10 +57,10 @@ _unwrap_val(B) = B
 
 # Arguments
 - `order::Integer`: Order of the integrated Wiener process (IWP) prior.
+- `smooth::Bool`: Turn smoothing on/off; smoothing is required for dense output.
 - `prior::AbstractODEFilterPrior`: Prior to be used by the ODE filter.
    By default, uses a 3-times integrated Wiener process prior `IWP(3)`.
    See also: [Priors](@ref).
-- `smooth::Bool`: Turn smoothing on/off; smoothing is required for dense output.
 - `diffusionmodel::ProbNumDiffEq.AbstractDiffusion`: See [Diffusion models and calibration](@ref).
 - `initialization::ProbNumDiffEq.InitializationScheme`: See [Initialization](@ref).
 

--- a/src/diffusions.jl
+++ b/src/diffusions.jl
@@ -14,9 +14,10 @@ estimate_global_diffusion(diffusion::AbstractDynamicDiffusion, d, q, Eltype) = N
 """
     DynamicDiffusion()
 
-**Recommended with adaptive steps**
+Time-varying, isotropic diffusion, which is quasi-maximum-likelihood-estimated at each step.
 
-A local diffusion parameter is estimated at each step. Works well with adaptive steps.
+**This is the recommended diffusion when using adaptive step-size selection,** and in
+particular also when solving stiff systems.
 """
 struct DynamicDiffusion <: AbstractDynamicDiffusion end
 initial_diffusion(::DynamicDiffusion, d, q, Eltype) = one(Eltype)
@@ -25,14 +26,16 @@ estimate_local_diffusion(::DynamicDiffusion, integ) = local_scalar_diffusion(int
 """
     DynamicMVDiffusion()
 
-**Only works with the [`EK0`](@ref)**
+Time-varying, diagonal diffusion, which is quasi-maximum-likelihood-estimated at each step.
 
-A multi-variate version of [`DynamicDiffusion`](@ref), where instead of a scalar a
-vector-valued diffusion is estimated. When using the EK0, this can be helpful when the
-scales of the different dimensions vary a lot.
+**Only works with the [`EK0`](@ref)!**
 
-# References
-- N. Bosch, P. Hennig, F. Tronarp: **Calibrated Adaptive Probabilistic ODE Solvers** (2021)
+A multi-variate version of [`DynamicDiffusion`](@ref), where instead of an isotropic matrix,
+a diagonal matrix is estimated. This can be helpful to get more expressive posterior
+covariances when using the [`EK0`](@ref), since the individual dimensions can be adjusted
+separately.
+
+See also [[1]](@ref diffusionrefs).
 """
 struct DynamicMVDiffusion <: AbstractDynamicDiffusion end
 initial_diffusion(::DynamicMVDiffusion, d, q, Eltype) =
@@ -43,11 +46,14 @@ estimate_local_diffusion(::DynamicMVDiffusion, integ) =
 """
     FixedDiffusion(; initial_diffusion=1.0, calibrate=true)
 
-**Recommended with fixed steps**
+Time-fixed, isotropic diffusion, which is (optionally) quasi-maximum-likelihood-estimated.
 
-If `calibrate=true`, the probabilistic solution is calibrated once at the end of the solve.
-An initial diffusion parameter can be passed, but this only has an effect if
-`calibrate=false` - which is typically not recommended.
+**This is the recommended diffusion when using fixed steps.**
+
+By default with `calibrate=true`, all covariances are re-scaled at the end of the solve
+with the MLE diffusion. Set `calibrate=false` to skip this step, e.g. when setting the
+`initial_diffusion` and then estimating the diffusion outside of the solver
+(e.g. with [Fenrir.jl](https://github.com/nathanaelbosch/Fenrir.jl)).
 """
 Base.@kwdef struct FixedDiffusion{T<:Number} <: AbstractStaticDiffusion
     initial_diffusion::T = 1.0
@@ -85,14 +91,16 @@ end
 """
     FixedMVDiffusion(; initial_diffusion=1.0, calibrate=true)
 
-**Only works with the [`EK0`](@ref)**
+Time-fixed, diagonal diffusion, which is quasi-maximum-likelihood-estimated at each step.
 
-A multi-variate version of [`FixedDiffusion`](@ref), where instead of a scalar a
-vector-valued diffusion is estimated. When using the EK0, this can be helpful when the
-scales of the different dimensions vary a lot.
+**Only works with the [`EK0`](@ref)!**
 
-# References
-- N. Bosch, P. Hennig, F. Tronarp: **Calibrated Adaptive Probabilistic ODE Solvers** (2021)
+A multi-variate version of [`FixedDiffusion`](@ref), where instead of an isotropic matrix,
+a diagonal matrix is estimated. This can be helpful to get more expressive posterior
+covariances when using the [`EK0`](@ref), since the individual dimensions can be adjusted
+separately.
+
+See also [[1]](@ref diffusionrefs).
 """
 Base.@kwdef struct FixedMVDiffusion{T} <: AbstractStaticDiffusion
     initial_diffusion::T = 1.0

--- a/src/priors/ioup.jl
+++ b/src/priors/ioup.jl
@@ -1,4 +1,4 @@
-"""
+@doc raw"""
     IOUP([wiener_process_dimension::Integer,]
          num_derivatives::Integer,
          rate_parameter::Union{Number,AbstractVector,AbstractMatrix})
@@ -9,6 +9,15 @@ As with the [`IWP`](@ref), the IOUP can be created without specifying its dimens
 in which case it will be inferred from the dimension of the ODE during the solve.
 This is typically the preferred usage.
 The rate parameter however always needs to be specified.
+
+# In math
+```math
+\begin{aligned}
+\text{d} Y^{(i)}(t) &= Y^{(i+1)}(t) \ \text{d}t, \qquad i = 0, \dots, q-1 \\
+\text{d} Y^{(q)}(t) &= L Y^{(q)}(t) \ \text{d}t + \Gamma \ \text{d}W(t),
+\end{aligned}
+```
+where ``L`` is the `rate_parameter`.
 
 # Examples
 ```julia-repl

--- a/src/priors/iwp.jl
+++ b/src/priors/iwp.jl
@@ -1,11 +1,24 @@
-"""
+@doc raw"""
     IWP([wiener_process_dimension::Integer,] num_derivatives::Integer)
 
 Integrated Wiener process.
 
+**This is the recommended prior!** It is the most well-tested prior, both in this package
+and in the probabilistic numerics literature in general
+(see the [references](@ref references)).
+It is also the prior that has the most efficient implementation.
+
 The IWP can be created without specifying the dimension of the Wiener process,
 in which case it will be inferred from the dimension of the ODE during the solve.
 This is typically the preferred usage.
+
+# In math
+```math
+\begin{aligned}
+\text{d} Y^{(i)}(t) &= Y^{(i+1)}(t) \ \text{d}t, \qquad i = 0, \dots, q-1 \\
+\text{d} Y^{(q)}(t) &= \Gamma \ \text{d}W(t).
+\end{aligned}
+```
 
 # Examples
 ```julia-repl

--- a/src/priors/matern.jl
+++ b/src/priors/matern.jl
@@ -1,4 +1,4 @@
-"""
+@doc raw"""
     Matern([wiener_process_dimension::Integer,]
            num_derivatives::Integer,
            lengthscale::Number)
@@ -9,6 +9,18 @@ As with the [`IWP`](@ref), the Matern can be created without specifying its dime
 in which case it will be inferred from the dimension of the ODE during the solve.
 This is typically the preferred usage.
 The lengthscale parameter however always needs to be specified.
+
+# In math
+```math
+\begin{aligned}
+\text{d} Y^{(i)}(t) &= Y^{(i+1)}(t) \ \text{d}t, \qquad i = 0, \dots, q-1 \\
+\text{d} Y^{(q)}(t) &= - \sum_{j=0}^q \left(
+  \begin{pmatrix} q+1 \\ j \end{pmatrix}
+  \left( \frac{\sqrt{2q - 1}}{l} \right)^{q-j}
+  Y^{(j)}(t) \right) \ \text{d}t + \Gamma \ \text{d}W(t).
+\end{aligned}
+```
+where ``l`` is the `lengthscale`.
 
 # Examples
 ```julia-repl


### PR DESCRIPTION
Still to do: Go through the individual pages, add text, and update some docstrings.
- [x] Diffusions
- [x] Priors
- [x] Initialization
- [x] Solvers