### PR TITLE
Change the keyword argument from `init_on_du` to `init_on_ddu`

### DIFF
--- a/benchmarks/lotkavolterra.jmd
+++ b/benchmarks/lotkavolterra.jmd
@@ -188,9 +188,9 @@ _setups = [
   "EK1(2) Tsit5Init" => Dict(:alg => EK1(order=2, smooth=DENSE, initialization=ClassicSolverInit()))
   "EK1(3) Tsit5Init" => Dict(:alg => EK1(order=3, smooth=DENSE, initialization=ClassicSolverInit()))
   "EK1(5) Tsit5Init" => Dict(:alg => EK1(order=5, smooth=DENSE, initialization=ClassicSolverInit()))
-  "EK1(2) Tsit5Init+du" => Dict(:alg => EK1(order=2, smooth=DENSE, initialization=ClassicSolverInit(init_on_du=true)))
-  "EK1(3) Tsit5Init+du" => Dict(:alg => EK1(order=3, smooth=DENSE, initialization=ClassicSolverInit(init_on_du=true)))
-  "EK1(5) Tsit5Init+du" => Dict(:alg => EK1(order=5, smooth=DENSE, initialization=ClassicSolverInit(init_on_du=true)))
+  "EK1(2) Tsit5Init+ddu" => Dict(:alg => EK1(order=2, smooth=DENSE, initialization=ClassicSolverInit(init_on_ddu=true)))
+  "EK1(3) Tsit5Init+ddu" => Dict(:alg => EK1(order=3, smooth=DENSE, initialization=ClassicSolverInit(init_on_ddu=true)))
+  "EK1(5) Tsit5Init+ddu" => Dict(:alg => EK1(order=5, smooth=DENSE, initialization=ClassicSolverInit(init_on_ddu=true)))
 ]
 
 labels = first.(_setups)

--- a/docs/src/benchmarks/lotkavolterra.md
+++ b/docs/src/benchmarks/lotkavolterra.md
@@ -211,9 +211,9 @@ _setups = [
   "EK1(2) Tsit5Init" => Dict(:alg => EK1(order=2, smooth=DENSE, initialization=ClassicSolverInit()))
   "EK1(3) Tsit5Init" => Dict(:alg => EK1(order=3, smooth=DENSE, initialization=ClassicSolverInit()))
   "EK1(5) Tsit5Init" => Dict(:alg => EK1(order=5, smooth=DENSE, initialization=ClassicSolverInit()))
-  "EK1(2) Tsit5Init+du" => Dict(:alg => EK1(order=2, smooth=DENSE, initialization=ClassicSolverInit(init_on_du=true)))
-  "EK1(3) Tsit5Init+du" => Dict(:alg => EK1(order=3, smooth=DENSE, initialization=ClassicSolverInit(init_on_du=true)))
-  "EK1(5) Tsit5Init+du" => Dict(:alg => EK1(order=5, smooth=DENSE, initialization=ClassicSolverInit(init_on_du=true)))
+  "EK1(2) Tsit5Init+ddu" => Dict(:alg => EK1(order=2, smooth=DENSE, initialization=ClassicSolverInit(init_on_ddu=true)))
+  "EK1(3) Tsit5Init+ddu" => Dict(:alg => EK1(order=3, smooth=DENSE, initialization=ClassicSolverInit(init_on_ddu=true)))
+  "EK1(5) Tsit5Init+ddu" => Dict(:alg => EK1(order=5, smooth=DENSE, initialization=ClassicSolverInit(init_on_ddu=true)))
 ]
 
 labels = first.(_setups)
@@ -274,5 +274,3 @@ Environment:
   JULIA_NUM_THREADS = auto
   JULIA_STACKTRACE_MINIMAL = true
 ```
-
-

--- a/src/initialization/classicsolverinit.jl
+++ b/src/initialization/classicsolverinit.jl
@@ -23,7 +23,7 @@ function initial_update!(integ, cache, ::ClassicSolverInit)
     end
 
     # Use a jac or autodiff to initialize on ddu0
-    if f isa ODEFunction && integ.alg.initialization.init_on_du
+    if f isa ODEFunction && integ.alg.initialization.init_on_ddu
         _f = if f.f isa SciMLBase.FunctionWrappersWrappers.FunctionWrappersWrapper
             ODEFunction(SciMLBase.unwrapped_f(f), mass_matrix=f.mass_matrix)
         else

--- a/src/initialization/common.jl
+++ b/src/initialization/common.jl
@@ -15,7 +15,7 @@ In case of errors, try [`ClassicSolverInit`](@ref).
 struct TaylorModeInit <: InitializationScheme end
 
 """
-    ClassicSolverInit(; alg=OrdinaryDiffEq.Tsit5(), init_on_du=false)
+    ClassicSolverInit(; alg=OrdinaryDiffEq.Tsit5(), init_on_ddu=false)
 
 Exact initialization with a classic ODE solver. The solver to be used can be set with the
 `alg` keyword argument. `init_on_du` specifies if ForwardDiff.jl should be used to compute
@@ -25,7 +25,7 @@ Not recommended for large solver orders, say `order>4`.
 """
 Base.@kwdef struct ClassicSolverInit{ALG} <: InitializationScheme
     alg::ALG = Tsit5()
-    init_on_du::Bool = false
+    init_on_ddu::Bool = false
 end
 
 """

--- a/test/state_init.jl
+++ b/test/state_init.jl
@@ -54,7 +54,8 @@ end
     Proj1 = integ1.cache.Proj
 
     @testset "Order $o" for o in (1, 2, 3, 4, 5)
-        integ2 = init(prob, EK0(order=o, initialization=ClassicSolverInit(init_on_ddu=true)))
+        integ2 =
+            init(prob, EK0(order=o, initialization=ClassicSolverInit(init_on_ddu=true)))
         rk_init = integ2.cache.x.μ
         Proj2 = integ2.cache.Proj
 

--- a/test/state_init.jl
+++ b/test/state_init.jl
@@ -54,7 +54,7 @@ end
     Proj1 = integ1.cache.Proj
 
     @testset "Order $o" for o in (1, 2, 3, 4, 5)
-        integ2 = init(prob, EK0(order=o, initialization=ClassicSolverInit(init_on_du=true)))
+        integ2 = init(prob, EK0(order=o, initialization=ClassicSolverInit(init_on_ddu=true)))
         rk_init = integ2.cache.x.μ
         Proj2 = integ2.cache.Proj
 


### PR DESCRIPTION
The old thing basically didn't make any sense, since they keyword is there to specify if the second derivative (i.e. `ddu`) should be initialized exaclty or not.