### PR TITLE
Fix the EK0 for SecondOrderODEProblems

### DIFF
--- a/src/caches.jl
+++ b/src/caches.jl
@@ -168,7 +168,7 @@ function OrdinaryDiffEq.alg_cache(
         similar(Array{uElType}, _d),
         PSDMatrix(
             if FAC isa IsometricKroneckerCovariance
-                Kronecker.kronecker(similar(Matrix{uElType}, D÷d, _d÷d), I(d))
+                Kronecker.kronecker(similar(Matrix{uElType}, D ÷ d, _d ÷ d), I(d))
             else
                 similar(Matrix{uElType}, D, _d)
             end,

--- a/src/caches.jl
+++ b/src/caches.jl
@@ -110,7 +110,11 @@ function OrdinaryDiffEq.alg_cache(
     E0, E1, E2 = Proj(0), Proj(1), Proj(2)
     @assert f isa SciMLBase.AbstractODEFunction
     SolProj = if is_secondorder_ode
-        [Proj(1); Proj(0)]
+        if FAC isa IsometricKroneckerCovariance
+            [Proj(1).B; Proj(0).B]
+        else
+            [Proj(1); Proj(0)]
+        end
     else
         Proj(0)
     end

--- a/src/caches.jl
+++ b/src/caches.jl
@@ -110,8 +110,7 @@ function OrdinaryDiffEq.alg_cache(
     E0, E1, E2 = Proj(0), Proj(1), Proj(2)
     @assert f isa SciMLBase.AbstractODEFunction
     SolProj = if is_secondorder_ode
-        E0 isa IsometricKroneckerProduct ?
-        IsometricKroneckerProduct(d, [Proj(1).B; Proj(0).B]) : [Proj(1); Proj(0)]
+        [Proj(1); Proj(0)]
     else
         Proj(0)
     end

--- a/src/caches.jl
+++ b/src/caches.jl
@@ -160,7 +160,11 @@ function OrdinaryDiffEq.alg_cache(
         similar(Array{uElType}, _d),
         PSDMatrix(
             if FAC isa IsometricKroneckerCovariance
-                Kronecker.kronecker(similar(Matrix{uElType}, D ÷ d, _d ÷ d), I(d))
+                if is_secondorder_ode
+                    Kronecker.kronecker(similar(Matrix{uElType}, D ÷ d, _d ÷ d), I(d))
+                else
+                    factorized_similar(FAC, D, d)
+                end
             else
                 similar(Matrix{uElType}, D, _d)
             end,

--- a/src/caches.jl
+++ b/src/caches.jl
@@ -109,15 +109,7 @@ function OrdinaryDiffEq.alg_cache(
     Proj = projection(FAC)
     E0, E1, E2 = Proj(0), Proj(1), Proj(2)
     @assert f isa SciMLBase.AbstractODEFunction
-    SolProj = if is_secondorder_ode
-        if FAC isa IsometricKroneckerCovariance
-            [Proj(1).B; Proj(0).B]
-        else
-            [Proj(1); Proj(0)]
-        end
-    else
-        Proj(0)
-    end
+    SolProj = solution_space_projection(FAC, is_secondorder_ode)
 
     # Prior dynamics
     prior = if alg.prior isa IWP

--- a/src/diffusions.jl
+++ b/src/diffusions.jl
@@ -200,7 +200,7 @@ function local_diagonal_diffusion(cache)
     c1 = view(HQH.R, :, 1)
     Q0_11 = dot(c1, c1)
 
-    Σ_ii = @. tmp = z^2 / Q0_11
+    Σ_ii = @. m_tmp.μ = z^2 / Q0_11
     # Σ_ii .= max.(Σ_ii, eps(eltype(Σ_ii)))
     Σ = Diagonal(Σ_ii)
 

--- a/src/integrator_utils.jl
+++ b/src/integrator_utils.jl
@@ -58,7 +58,7 @@ function calibrate_solution!(integ, mle_diffusion)
 
     # Re-write into the solution estimates
     for (pu, x) in zip(integ.sol.pu, integ.sol.x_filt)
-        _gaussian_mul!(pu, integ.cache.SolProj, x)
+        write_into_pu!(pu, x; cache=integ.cache, is_secondorder_ode=integ.f isa DynamicalODEFunction)
     end
     # [(su[:] .= pu) for (su, pu) in zip(integ.sol.u, integ.sol.pu.μ)]
 end
@@ -109,7 +109,12 @@ function smooth_solution!(integ)
         K = backward_kernels[i]
         marginalize!(x_smooth[i], x_smooth[i+1], K; C_DxD, C_3DxD)
 
-        _gaussian_mul!(sol.pu[i], cache.SolProj, x_smooth[i])
+        write_into_pu!(
+            sol.pu[i],
+            x_smooth[i];
+            cache=integ.cache,
+            is_secondorder_ode=integ.f isa DynamicalODEFunction,
+        )
         sol.u[i][:] .= sol.pu[i].μ
     end
     return nothing
@@ -129,7 +134,12 @@ function pn_solution_endpoint_match_cur_integrator!(integ)
         OrdinaryDiffEq.copyat_or_push!(
             integ.sol.pu,
             integ.saveiter,
-            _gaussian_mul!(integ.cache.pu_tmp, integ.cache.SolProj, integ.cache.x),
+            write_into_pu!(
+                integ.cache.pu_tmp,
+                integ.cache.x;
+                cache=integ.cache,
+                is_secondorder_ode=integ.f isa DynamicalODEFunction,
+            ),
         )
     end
 end
@@ -149,7 +159,8 @@ function DiffEqBase.savevalues!(
         i = integ.saveiter
         OrdinaryDiffEq.copyat_or_push!(integ.sol.diffusions, i, integ.cache.local_diffusion)
         OrdinaryDiffEq.copyat_or_push!(integ.sol.x_filt, i, integ.cache.x)
-        _gaussian_mul!(integ.cache.pu_tmp, integ.cache.SolProj, integ.cache.x)
+        write_into_pu!(integ.cache.pu_tmp, integ.cache.x;
+                       cache=integ.cache, is_secondorder_ode=integ.f isa DynamicalODEFunction),
         OrdinaryDiffEq.copyat_or_push!(integ.sol.pu, i, integ.cache.pu_tmp)
 
         if integ.alg.smooth

--- a/src/integrator_utils.jl
+++ b/src/integrator_utils.jl
@@ -109,7 +109,7 @@ function smooth_solution!(integ)
         K = backward_kernels[i]
         marginalize!(x_smooth[i], x_smooth[i+1], K; C_DxD, C_3DxD)
 
-_gaussian_mul!(sol.pu[i], cache.SolProj, x_smooth[i])
+        _gaussian_mul!(sol.pu[i], cache.SolProj, x_smooth[i])
         sol.u[i][:] .= sol.pu[i].μ
     end
     return nothing

--- a/src/integrator_utils.jl
+++ b/src/integrator_utils.jl
@@ -58,7 +58,12 @@ function calibrate_solution!(integ, mle_diffusion)
 
     # Re-write into the solution estimates
     for (pu, x) in zip(integ.sol.pu, integ.sol.x_filt)
-        write_into_pu!(pu, x; cache=integ.cache, is_secondorder_ode=integ.f isa DynamicalODEFunction)
+        write_into_pu!(
+            pu,
+            x;
+            cache=integ.cache,
+            is_secondorder_ode=integ.f isa DynamicalODEFunction,
+        )
     end
     # [(su[:] .= pu) for (su, pu) in zip(integ.sol.u, integ.sol.pu.μ)]
 end
@@ -160,7 +165,7 @@ function DiffEqBase.savevalues!(
         OrdinaryDiffEq.copyat_or_push!(integ.sol.diffusions, i, integ.cache.local_diffusion)
         OrdinaryDiffEq.copyat_or_push!(integ.sol.x_filt, i, integ.cache.x)
         write_into_pu!(integ.cache.pu_tmp, integ.cache.x;
-                       cache=integ.cache, is_secondorder_ode=integ.f isa DynamicalODEFunction),
+            cache=integ.cache, is_secondorder_ode=integ.f isa DynamicalODEFunction),
         OrdinaryDiffEq.copyat_or_push!(integ.sol.pu, i, integ.cache.pu_tmp)
 
         if integ.alg.smooth

--- a/src/kronecker.jl
+++ b/src/kronecker.jl
@@ -1,3 +1,4 @@
+copy(K::Kronecker.KroneckerProduct) = Kronecker.KroneckerProduct(copy(K.A), copy(K.B))
 @doc raw"""
     IsometricKroneckerProduct(left_factor_dim::Int64, right_factor::AbstractMatrix)
 

--- a/src/perform_step.jl
+++ b/src/perform_step.jl
@@ -43,41 +43,6 @@ function write_into_solution!(u, μ; cache::EKCache, is_secondorder_ode=false)
         _matmul!(view(u, :), cache.E0, μ)
     end
 end
-function write_into_pu!(pu, x; cache::EKCache, is_secondorder_ode=false)
-    d = cache.d
-    if !(pu.Σ.R isa Kronecker.KroneckerProduct)
-        _gaussian_mul!(pu, cache.SolProj, x)
-    else
-        if !is_secondorder_ode
-            @assert cache.SolProj == cache.E0
-            _matmul!(view(pu.μ, 1:d), cache.E0, x.μ)
-            _matmul!(pu.Σ.R.A, x.Σ.R.B, cache.E0.B')
-        else
-            _gaussian_mul!(pu, cache.SolProj, x)
-            # _matmul!(view(pu.μ, 1:d), cache.E1, x.μ)
-            # _matmul!(view(pu.μ, d+1:2d), cache.E0, x.μ)
-            # _matmul!(pu.Σ.R.A, x.Σ.R.B, cache.SolProj')
-        end
-    end
-    return pu
-end
-function project_to_solution_space(pu, x; integ::EKCache, is_secondorder_ode=false)
-    d = cache.d
-    if !(pu.Σ.R isa Kronecker.KroneckerProduct)
-        _gaussian_mul!(pu, cache.SolProj, x)
-    else
-        if !is_secondorder_ode
-            @assert cache.SolProj == cache.E0
-            _matmul!(view(pu.μ, 1:d), cache.E0, x.μ)
-            _matmul!(pu.Σ.R.A, x.Σ.R.B, cache.E0.B')
-        else
-            _matmul!(view(pu.μ, 1:d), cache.E1, x.μ)
-            _matmul!(view(pu.μ, d+1:2d), cache.E0, x.μ)
-            _matmul!(pu.Σ.R.A, x.Σ.R.B, cache.SolProj')
-        end
-    end
-    return pu
-end
 
 """
     perform_step!(integ, cache::EKCache[, repeat_step=false])

--- a/src/perform_step.jl
+++ b/src/perform_step.jl
@@ -58,6 +58,24 @@ function write_into_pu!(pu, x; cache::EKCache, is_secondorder_ode=false)
             _matmul!(view(pu.μ, 1:d), cache.E0, x.μ)
             _matmul!(pu.Σ.R.A, x.Σ.R.B, cache.E0.B')
         else
+            _gaussian_mul!(pu, cache.SolProj, x)
+            # _matmul!(view(pu.μ, 1:d), cache.E1, x.μ)
+            # _matmul!(view(pu.μ, d+1:2d), cache.E0, x.μ)
+            # _matmul!(pu.Σ.R.A, x.Σ.R.B, cache.SolProj')
+        end
+    end
+    return pu
+end
+function project_to_solution_space(pu, x; integ::EKCache, is_secondorder_ode=false)
+    d = cache.d
+    if !(pu.Σ.R isa Kronecker.KroneckerProduct)
+        _gaussian_mul!(pu, cache.SolProj, x)
+    else
+        if !is_secondorder_ode
+            @assert cache.SolProj == cache.E0
+            _matmul!(view(pu.μ, 1:d), cache.E0, x.μ)
+            _matmul!(pu.Σ.R.A, x.Σ.R.B, cache.E0.B')
+        else
             _matmul!(view(pu.μ, 1:d), cache.E1, x.μ)
             _matmul!(view(pu.μ, d+1:2d), cache.E0, x.μ)
             _matmul!(pu.Σ.R.A, x.Σ.R.B, cache.SolProj')

--- a/src/perform_step.jl
+++ b/src/perform_step.jl
@@ -60,7 +60,7 @@ function write_into_pu!(pu, x; cache::EKCache, is_secondorder_ode=false)
         else
             _matmul!(view(pu.μ, 1:d), cache.E1, x.μ)
             _matmul!(view(pu.μ, d+1:2d), cache.E0, x.μ)
-            _matmul!(pu.Σ.R.A, x.Σ.R.B, cache.SolProj)
+            _matmul!(pu.Σ.R.A, x.Σ.R.B, cache.SolProj')
         end
     end
     return pu

--- a/src/perform_step.jl
+++ b/src/perform_step.jl
@@ -14,12 +14,7 @@ function OrdinaryDiffEq.initialize!(integ::OrdinaryDiffEq.ODEIntegrator, cache::
 
     # These are necessary since the solution object is not 100% initialized by default
     OrdinaryDiffEq.copyat_or_push!(integ.sol.x_filt, integ.saveiter, cache.x)
-    initial_pu = write_into_pu!(
-        cache.pu_tmp,
-        cache.x;
-        cache=integ.cache,
-        is_secondorder_ode=integ.f isa DynamicalODEFunction,
-    )
+    initial_pu = _gaussian_mul!(cache.pu_tmp, cache.SolProj, cache.x)
     OrdinaryDiffEq.copyat_or_push!(integ.sol.pu, integ.saveiter, initial_pu)
 
     return nothing

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -61,7 +61,9 @@ function Base.:*(M::SecondOrderODESolutionProjector, x::SRGaussian)
     @unpack d = M.covariance_structure
     E0 = IsometricKroneckerProduct(d, M.E0B)
     E1 = IsometricKroneckerProduct(d, M.E1B)
-    return [E1; E0] * x
+    μ = [E1 * x.μ; E0 * x.μ]
+    Σ = PSDMatrix([x.Σ.R * E1' x.Σ.R * E0'])
+    return Gaussian(μ, Σ)
 end
 
 function solution_space_projection(C::IsometricKroneckerCovariance, is_secondorder_ode)

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -27,3 +27,48 @@ function projection(C::IsometricKroneckerCovariance{elType}) where {elType}
     end
     return Proj
 end
+
+function solution_space_projection(C::CovarianceStructure, is_secondorder_ode)
+    Proj = projection(C)
+    if is_secondorder_ode
+        return [Proj(1); Proj(0)]
+    else
+        return Proj(0)
+    end
+end
+
+struct SecondOrderODESolutionProjector{T,FAC,M} <: AbstractMatrix{T}
+    covariance_structure::FAC
+    E0B::M
+    E1B::M
+end
+function SecondOrderODESolutionProjector(C::IsometricKroneckerCovariance{T}) where {T}
+    Proj = projection(C)
+    E0B, E1B = Proj(0).B, Proj(1).B
+    return SecondOrderODESolutionProjector{T,typeof(C),typeof(E0B)}(C, E0B, E1B)
+end
+function _gaussian_mul!(
+    g_out::SRGaussian, M::SecondOrderODESolutionProjector, g_in::SRGaussian)
+    @unpack d = M.covariance_structure
+    E0 = IsometricKroneckerProduct(d, M.E0B)
+    E1 = IsometricKroneckerProduct(d, M.E1B)
+    _matmul!(view(g_out.μ, 1:d), E1, g_in.μ)
+    _matmul!(view(g_out.μ, d+1:2d), E0, g_in.μ)
+    _matmul!(g_out.Σ.R.A, g_in.Σ.R.B, [M.E1B; M.E0B]')
+    return g_out
+end
+function Base.:*(M::SecondOrderODESolutionProjector, x::SRGaussian)
+    @unpack d = M.covariance_structure
+    E0 = IsometricKroneckerProduct(d, M.E0B)
+    E1 = IsometricKroneckerProduct(d, M.E1B)
+    return [E1; E0] * x
+end
+
+function solution_space_projection(C::IsometricKroneckerCovariance, is_secondorder_ode)
+    Proj = projection(C)
+    if is_secondorder_ode
+        return SecondOrderODESolutionProjector(C)
+    else
+        return Proj(0)
+    end
+end

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -90,14 +90,9 @@ function DiffEqBase.build_solution(
     N = length((size(prob.u0)..., length(u)))
 
     uElType = eltype(prob.u0)
-    d, q = cache.d, cache.q
-    D = d * (q + 1)
 
-    FAC = cache.covariance_factorization
-    pu_cov = PSDMatrix(factorized_zeros(FAC, D, d))
-    x_cov = PSDMatrix(factorized_zeros(FAC, D, D))
-    pu = StructArray{Gaussian{Vector{uElType},typeof(pu_cov)}}(undef, 0)
-    x_filt = StructArray{Gaussian{Vector{uElType},typeof(x_cov)}}(undef, 0)
+    pu = StructArray{typeof(cache.pu_tmp)}(undef, 0)
+    x_filt = StructArray{typeof(cache.x)}(undef, 0)
     x_smooth = copy(x_filt)
 
     backward_kernels = StructArray{typeof(cache.backward_kernel)}(undef, 0)
@@ -112,9 +107,7 @@ function DiffEqBase.build_solution(
         errors = nothing
     end
 
-    uElTypeNoUnits = OrdinaryDiffEq.recursive_unitless_bottom_eltype(u)
-    q = 1
-    diffusion_prototype = initial_diffusion(alg.diffusionmodel, d, q, uElTypeNoUnits)
+    diffusion_prototype = cache.default_diffusion
 
     ll = zero(uElType)
     return ProbODESolution{T,N}(

--- a/test/secondorderode.jl
+++ b/test/secondorderode.jl
@@ -41,7 +41,7 @@ ALGS = (
         EK0(diffusionmodel=FixedMVDiffusion()),
         EK0(diffusionmodel=DynamicMVDiffusion()),
     )
-        @test_nowarn solve(_prob, alg)
+        @test solve(_prob, alg) isa ProbNumDiffEq.AbstractProbODESolution
 
         sol = solve(_prob, alg, abstol=1e-7, reltol=1e-7)
         @test sol isa ProbNumDiffEq.ProbODESolution
@@ -51,6 +51,7 @@ ALGS = (
     end
 
     @testset "ClassicSolverInit" begin
-        @test_nowarn solve(_prob, EK1(initialization=ClassicSolverInit()))
+        @test solve(_prob, EK1(initialization=ClassicSolverInit())) isa
+              ProbNumDiffEq.AbstractProbODESolution
     end
 end

--- a/test/secondorderode.jl
+++ b/test/secondorderode.jl
@@ -35,6 +35,8 @@ ALGS = (
     @testset "$alg" for alg in (
         EK0(),
         EK1(),
+        EK0(initialization=ForwardDiffInit(2)),
+        EK1(initialization=ForwardDiffInit(2)),
         EK1(diffusionmodel=FixedDiffusion()),
         EK0(diffusionmodel=FixedMVDiffusion()),
         EK0(diffusionmodel=DynamicMVDiffusion()),

--- a/test/secondorderode.jl
+++ b/test/secondorderode.jl
@@ -1,69 +1,54 @@
 using ProbNumDiffEq
 using OrdinaryDiffEq
+using LinearAlgebra
 using Test
 
-du0 = [0.0]
-u0 = [2.0]
-tspan = (0.0, 0.1)
-p = [1e1]
-
-function vanderpol!(ddu, du, u, p, t)
-    μ = p[1]
-    @. ddu = μ * ((1 - u^2) * du - u)
+function twobody(du, u, p, t)
+    R3 = norm(u[1:2])^3
+    @. du[3:4] = -u[1:2] / R3
+    @. du[1:2] = u[3:4]
 end
-const prob_iip = SecondOrderODEProblem(vanderpol!, du0, u0, tspan, p)
+u0, du0 = [0.4, 0.0], [0.0, 2.0]
+tspan = (0, 2π)
+prob_base = ODEProblem(twobody, [u0...; du0...], tspan)
 
-function vanderpol(du, u, p, t)
-    μ = p[1]
-    ddu = μ .* ((1 .- u .^ 2) .* du .- u)
-    return ddu
+function twobody2_iip(ddu, du, u, p, t)
+    R3 = norm(u)^3
+    @. ddu = -u / R3
 end
-const prob_oop = SecondOrderODEProblem(vanderpol, du0, u0, tspan, p)
+prob_iip = SecondOrderODEProblem(twobody2_iip, du0, u0, tspan)
 
-const appxsol = solve(prob_iip, Tsit5(), abstol=1e-7, reltol=1e-7)
+function twobody2_oop(du, u, p, t)
+    R3 = norm(u)^3
+    return -u / R3
+end
+prob_oop = SecondOrderODEProblem(twobody2_oop, du0, u0, tspan)
+
+appxsol = solve(prob_iip, Vern9(), abstol=1e-10, reltol=1e-10)
 
 ALGS = (
     EK0(),
     EK1(),
 )
 
-@testset "IIP" begin
-    for alg in ALGS
-        @testset "$alg" begin
-            sol = solve(prob_iip, alg)
-            # @test sol isa ProbNumDiffEq.ProbODESolution
-            # @test sol.u[end] ≈ appxsol.u[end] rtol = 1e-3
-        end
-    end
-end
-
-@testset "OOP" begin
-    for alg in ALGS
-        @testset "$alg" begin
-            sol = solve(prob_oop, alg)
-            @test sol isa ProbNumDiffEq.ProbODESolution
-            @test sol.u[end] ≈ appxsol.u[end] rtol = 1e-3
-        end
-    end
-end
-
-_name(structinstance) = typeof(structinstance).name.wrapper
-@testset "Diffusion: $(_name(DIFFUSION))" for DIFFUSION in (
-    FixedDiffusion(), DynamicDiffusion(), FixedMVDiffusion(), DynamicMVDiffusion())
-    @test_nowarn solve(
-        prob_iip,
-        EK0(diffusionmodel=FixedDiffusion(), smooth=false),
-        save_everystep=false,
-        dense=false,
+@testset "$S" for (S, _prob) in (("IIP", prob_iip), ("OOP", prob_oop))
+    @testset "$alg" for alg in (
+        EK0(),
+        EK1(),
+        EK1(diffusionmodel=FixedDiffusion()),
+        EK0(diffusionmodel=FixedMVDiffusion()),
+        EK0(diffusionmodel=DynamicMVDiffusion()),
     )
-end
+        @test_nowarn solve(_prob, alg)
 
-@testset "Initialization: $(_name(INIT))" for INIT in (
-    TaylorModeInit(3), ForwardDiffInit(3), SimpleInit(), ClassicSolverInit())
-    @test_nowarn solve(
-        prob_iip,
-        EK1(initialization=INIT, smooth=false),
-        save_everystep=false,
-        dense=false,
-    )
+        sol = solve(_prob, alg, abstol=1e-7, reltol=1e-7)
+        @test sol isa ProbNumDiffEq.ProbODESolution
+        @test sol.u[end] ≈ appxsol.u[end] rtol = 1e-3
+
+        @test sol(π).μ ≈ appxsol(π) rtol = 1e-3
+    end
+
+    @testset "ClassicSolverInit" begin
+        @test_nowarn solve(_prob, EK1(initialization=ClassicSolverInit()))
+    end
 end


### PR DESCRIPTION
It is currently broken: cache.SolProj is not actually the correct matrix to use to project to the solution. Basically, it is `I(d) \otimes [E_1; E_2]`, but it should be [I \otimes E1; I \otimes E2].


The solution probably goes something like this:
- p(u) (`pu`) is `A ⊗ I(d)`, instead of `I(d) ⊗ B`
- `pu.A = X_A_Xt(x.B, [Proj(1).B; Proj(0).B]`
At least in my repl this looks reasonable:
```julia
x = Gaussian(rand(6), ProbNumDiffEq.IsometricKroneckerProduct(2, Symmetric(rand(3,3))))
cov(x)
cov([Proj(1);Proj(0)]*x)
X_A_Xt(x.Σ.B, [Proj(1).B; Proj(0).B]) ⊗ I(2)

cov([Proj(1);Proj(0)]*x) == X_A_Xt(x.Σ.B, [Proj(1).B; Proj(0).B]) ⊗ I(2)
# true
```