### PR TITLE
Fix Downstream CI by only testing Fenrir's "Downstream" tests

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -18,7 +18,7 @@ jobs:
         julia-version: [1]
         os: [ubuntu-latest]
         package:
-          - {user: nathanaelbosch, repo: Fenrir.jl, group: All}
+          - {user: nathanaelbosch, repo: Fenrir.jl, group: Downstream}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This way Aqua and JET don't get tested anymore, which is the thing that currently makes the CI fail.