### PR TITLE
Implement observation noise for the PN likelihood

### DIFF
--- a/src/ProbNumDiffEq.jl
+++ b/src/ProbNumDiffEq.jl
@@ -43,6 +43,15 @@ X_A_Xt(A, X) = X * A * X'
 stack(x) = copy(reduce(hcat, x)')
 vecvec2mat(x) = reduce(hcat, x)'
 
+cov2psdmatrix(cov::Nothing; d) = nothing
+cov2psdmatrix(cov::Number; d) = PSDMatrix(sqrt(cov) * Eye(d))
+cov2psdmatrix(cov::UniformScaling; d) = PSDMatrix(sqrt(cov.λ) * Eye(d))
+cov2psdmatrix(cov::Diagonal; d) =
+    (@assert size(cov, 1) == size(cov, 2) == d; PSDMatrix(sqrt.(cov)))
+cov2psdmatrix(cov::AbstractMatrix; d) =
+    (@assert size(cov, 1) == size(cov, 2) == d; PSDMatrix(cholesky(cov).U))
+cov2psdmatrix(cov::PSDMatrix; d) = (@assert size(cov, 1) == size(cov, 2) == d; cov)
+
 include("fast_linalg.jl")
 include("kronecker.jl")
 include("covariance_structure.jl")

--- a/src/ProbNumDiffEq.jl
+++ b/src/ProbNumDiffEq.jl
@@ -43,7 +43,6 @@ X_A_Xt(A, X) = X * A * X'
 stack(x) = copy(reduce(hcat, x)')
 vecvec2mat(x) = reduce(hcat, x)'
 
-cov2psdmatrix(cov::Nothing; d) = nothing
 cov2psdmatrix(cov::Number; d) = PSDMatrix(sqrt(cov) * Eye(d))
 cov2psdmatrix(cov::UniformScaling; d) = PSDMatrix(sqrt(cov.λ) * Eye(d))
 cov2psdmatrix(cov::Diagonal; d) =

--- a/src/ProbNumDiffEq.jl
+++ b/src/ProbNumDiffEq.jl
@@ -48,7 +48,7 @@ cov2psdmatrix(cov::UniformScaling; d) = PSDMatrix(sqrt(cov.λ) * Eye(d))
 cov2psdmatrix(cov::Diagonal; d) =
     (@assert size(cov, 1) == size(cov, 2) == d; PSDMatrix(sqrt.(cov)))
 cov2psdmatrix(cov::AbstractMatrix; d) =
-    (@assert size(cov, 1) == size(cov, 2) == d; PSDMatrix(cholesky(cov).U))
+    (@assert size(cov, 1) == size(cov, 2) == d; PSDMatrix(Matrix(cholesky(cov).U)))
 cov2psdmatrix(cov::PSDMatrix; d) = (@assert size(cov, 1) == size(cov, 2) == d; cov)
 
 include("fast_linalg.jl")

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -12,8 +12,10 @@ function ekargcheck(alg; diffusionmodel, pn_observation_noise, kwargs...)
             ),
         )
     end
-    if ((diffusionmodel isa FixedMVDiffusion || diffusionmodel isa DynamicMVDiffusion) &&
-        diffusionmodel.calibrate) && alg == EK1
+    if (
+        (diffusionmodel isa FixedMVDiffusion || diffusionmodel isa DynamicMVDiffusion) &&
+        diffusionmodel.calibrate
+    ) && alg == EK1
         throw(
             ArgumentError(
                 "The `EK1` algorithm does not support automatic calibration of multivariate diffusion models. Either use the `EK0` instead, or use a scalar diffusion model, or set `calibrate=false` and calibrate manually by optimizing `sol.pnstats.log_likelihood`.",

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -13,9 +13,8 @@ function ekargcheck(alg; diffusionmodel, pn_observation_noise, kwargs...)
         )
     end
     if (
-        (diffusionmodel isa FixedMVDiffusion || diffusionmodel isa DynamicMVDiffusion) &&
-        diffusionmodel.calibrate
-    ) && alg == EK1
+        (diffusionmodel isa FixedMVDiffusion && diffusionmodel.calibrate)
+        || diffusionmodel isa DynamicMVDiffusion) && alg == EK1
         throw(
             ArgumentError(
                 "The `EK1` algorithm does not support automatic calibration of multivariate diffusion models. Either use the `EK0` instead, or use a scalar diffusion model, or set `calibrate=false` and calibrate manually by optimizing `sol.pnstats.log_likelihood`.",

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -12,11 +12,11 @@ function ekargcheck(alg; diffusionmodel, pn_observation_noise, kwargs...)
             ),
         )
     end
-    if (diffusionmodel isa FixedMVDiffusion || diffusionmodel isa DynamicMVDiffusion) &&
-       alg == EK1
+    if ((diffusionmodel isa FixedMVDiffusion || diffusionmodel isa DynamicMVDiffusion) &&
+        diffusionmodel.calibrate) && alg == EK1
         throw(
             ArgumentError(
-                "The `EK1` algorithm does not support multivariate diffusion models. Use `EK0` instead, or use a scalar diffusion model.",
+                "The `EK1` algorithm does not support automatic calibration of multivariate diffusion models. Either use the `EK0` instead, or use a scalar diffusion model, or set `calibrate=false` and calibrate manually by optimizing `sol.pnstats.log_likelihood`.",
             ),
         )
     end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -6,7 +6,7 @@ abstract type AbstractEK <: OrdinaryDiffEq.OrdinaryDiffEqAdaptiveAlgorithm end
 function ekargcheck(; diffusionmodel, pn_observation_noise, kwargs...)
     if (diffusionmodel isa AbstractStaticDiffusion && diffusionmodel.calibrate) &&
         (!isnothing(pn_observation_noise) && !iszero(pn_observation_noise))
-        throw(ArgumentError("Calibration of the diffusion model is not supported when using observation noise."))
+        throw(ArgumentError("Automatic calibration of global diffusion models is not possible when using observation noise. If you want to calibrate a global diffusion parameter, do so setting `calibrate=false` and optimizing `sol.pnstats.log_likelihood` manually."))
     end
 end
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -5,14 +5,22 @@ abstract type AbstractEK <: OrdinaryDiffEq.OrdinaryDiffEqAdaptiveAlgorithm end
 
 function ekargcheck(alg; diffusionmodel, pn_observation_noise, kwargs...)
     if (isstatic(diffusionmodel) && diffusionmodel.calibrate) &&
-        (!isnothing(pn_observation_noise) && !iszero(pn_observation_noise))
-        throw(ArgumentError("Automatic calibration of global diffusion models is not possible when using observation noise. If you want to calibrate a global diffusion parameter, do so setting `calibrate=false` and optimizing `sol.pnstats.log_likelihood` manually."))
+       (!isnothing(pn_observation_noise) && !iszero(pn_observation_noise))
+        throw(
+            ArgumentError(
+                "Automatic calibration of global diffusion models is not possible when using observation noise. If you want to calibrate a global diffusion parameter, do so setting `calibrate=false` and optimizing `sol.pnstats.log_likelihood` manually.",
+            ),
+        )
     end
-    if (diffusionmodel isa FixedMVDiffusion || diffusionmodel isa DynamicMVDiffusion) && alg == EK1
-        throw(ArgumentError("The `EK1` algorithm does not support multivariate diffusion models. Use `EK0` instead, or use a scalar diffusion model."))
+    if (diffusionmodel isa FixedMVDiffusion || diffusionmodel isa DynamicMVDiffusion) &&
+       alg == EK1
+        throw(
+            ArgumentError(
+                "The `EK1` algorithm does not support multivariate diffusion models. Use `EK0` instead, or use a scalar diffusion model.",
+            ),
+        )
     end
 end
-
 
 """
     EK0(; order=3,
@@ -56,11 +64,11 @@ struct EK0{PT,DT,IT,RT} <: AbstractEK
     initialization::IT
     pn_observation_noise::RT
     EK0(; order=3,
-         prior::PT=IWP(order),
-         diffusionmodel::DT=DynamicDiffusion(),
-         smooth=true,
-         initialization::IT=TaylorModeInit(num_derivatives(prior)),
-         pn_observation_noise::RT=nothing,
+        prior::PT=IWP(order),
+        diffusionmodel::DT=DynamicDiffusion(),
+        smooth=true,
+        initialization::IT=TaylorModeInit(num_derivatives(prior)),
+        pn_observation_noise::RT=nothing,
     ) where {PT,DT,IT,RT} = begin
         ekargcheck(EK0; diffusionmodel, pn_observation_noise)
         new{PT,DT,IT,RT}(

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -13,8 +13,8 @@ function ekargcheck(alg; diffusionmodel, pn_observation_noise, kwargs...)
         )
     end
     if (
-        (diffusionmodel isa FixedMVDiffusion && diffusionmodel.calibrate)
-        || diffusionmodel isa DynamicMVDiffusion) && alg == EK1
+        (diffusionmodel isa FixedMVDiffusion && diffusionmodel.calibrate) ||
+        diffusionmodel isa DynamicMVDiffusion) && alg == EK1
         throw(
             ArgumentError(
                 "The `EK1` algorithm does not support automatic calibration of multivariate diffusion models. Either use the `EK0` instead, or use a scalar diffusion model, or set `calibrate=false` and calibrate manually by optimizing `sol.pnstats.log_likelihood`.",

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -38,11 +38,12 @@ julia> solve(prob, EK0())
 
 # [References](@ref references)
 """
-struct EK0{PT,DT,IT} <: AbstractEK
+struct EK0{PT,DT,IT,RT} <: AbstractEK
     prior::PT
     diffusionmodel::DT
     smooth::Bool
     initialization::IT
+    pn_observation_noise::RT
 end
 EK0(;
     order=3,
@@ -50,7 +51,8 @@ EK0(;
     diffusionmodel=DynamicDiffusion(),
     smooth=true,
     initialization=TaylorModeInit(num_derivatives(prior)),
-) = EK0(prior, diffusionmodel, smooth, initialization)
+    pn_obervation_noise=nothing,
+) = EK0(prior, diffusionmodel, smooth, initialization, pn_obervation_noise)
 
 _unwrap_val(::Val{B}) where {B} = B
 _unwrap_val(B) = B
@@ -92,11 +94,12 @@ julia> solve(prob, EK1())
 
 # [References](@ref references)
 """
-struct EK1{CS,AD,DiffType,ST,CJ,PT,DT,IT} <: AbstractEK
+struct EK1{CS,AD,DiffType,ST,CJ,PT,DT,IT,RT} <: AbstractEK
     prior::PT
     diffusionmodel::DT
     smooth::Bool
     initialization::IT
+    pn_observation_noise::RT
 end
 EK1(;
     order=3,
@@ -109,7 +112,8 @@ EK1(;
     diff_type=Val{:forward},
     standardtag=Val{true}(),
     concrete_jac=nothing,
-) where {PT,DT,IT} =
+    pn_observation_noise::RT=nothing,
+) where {PT,DT,IT,RT} =
     EK1{
         _unwrap_val(chunk_size),
         _unwrap_val(autodiff),
@@ -119,11 +123,13 @@ EK1(;
         PT,
         DT,
         IT,
+        RT,
     }(
         prior,
         diffusionmodel,
         smooth,
         initialization,
+        pn_observation_noise,
     )
 
 """

--- a/src/caches.jl
+++ b/src/caches.jl
@@ -168,7 +168,8 @@ function OrdinaryDiffEq.alg_cache(
     copy!(x0.Σ, apply_diffusion(x0.Σ, initdiff))
 
     # Measurement model related things
-    R = isnothing(alg.pn_observation_noise) ? nothing :
+    R =
+        isnothing(alg.pn_observation_noise) ? nothing :
         to_factorized_matrix(FAC, cov2psdmatrix(alg.pn_observation_noise; d))
     H = factorized_similar(FAC, d, D)
     v = similar(Array{uElType}, d)

--- a/src/caches.jl
+++ b/src/caches.jl
@@ -168,11 +168,8 @@ function OrdinaryDiffEq.alg_cache(
     copy!(x0.Σ, apply_diffusion(x0.Σ, initdiff))
 
     # Measurement model related things
-    R = if isnothing(alg.pn_observation_noise)
-        nothing
-    else
+    R = isnothing(alg.pn_observation_noise) ? nothing :
         to_factorized_matrix(FAC, cov2psdmatrix(alg.pn_observation_noise; d))
-    end
     H = factorized_similar(FAC, d, D)
     v = similar(Array{uElType}, d)
     S = factorized_zeros(FAC, d, d)

--- a/src/caches.jl
+++ b/src/caches.jl
@@ -168,10 +168,10 @@ function OrdinaryDiffEq.alg_cache(
     copy!(x0.Σ, apply_diffusion(x0.Σ, initdiff))
 
     # Measurement model related things
-    R = nothing # factorized_similar(FAC, d, d)
+    R = cov2psdmatrix(alg.pn_observation_noise; d)
     H = factorized_similar(FAC, d, D)
     v = similar(Array{uElType}, d)
-    S = PSDMatrix(factorized_zeros(FAC, D, d))
+    S = factorized_zeros(FAC, d, d)
     measurement = Gaussian(v, S)
 
     # Caches

--- a/src/caches.jl
+++ b/src/caches.jl
@@ -168,7 +168,11 @@ function OrdinaryDiffEq.alg_cache(
     copy!(x0.Σ, apply_diffusion(x0.Σ, initdiff))
 
     # Measurement model related things
-    R = cov2psdmatrix(alg.pn_observation_noise; d)
+    R = if isnothing(alg.pn_observation_noise)
+        nothing
+    else
+        to_factorized_matrix(FAC, cov2psdmatrix(alg.pn_observation_noise; d))
+    end
     H = factorized_similar(FAC, d, D)
     v = similar(Array{uElType}, d)
     S = factorized_zeros(FAC, d, d)

--- a/src/callbacks/dataupdate.jl
+++ b/src/callbacks/dataupdate.jl
@@ -64,15 +64,7 @@ function DataUpdateCallback(
         obs_mean = _matmul!(view(m_tmp.μ, 1:o), H, x.μ)
         obs_mean .-= val
 
-        R = if observation_noise_cov isa PSDMatrix
-            observation_noise_cov
-        elseif observation_noise_cov isa Number
-            PSDMatrix(sqrt(observation_noise_cov) * Eye(o))
-        elseif observation_noise_cov isa UniformScaling
-            PSDMatrix(sqrt(observation_noise_cov.λ) * Eye(o))
-        else
-            PSDMatrix(cholesky(observation_noise_cov).U)
-        end
+        R = cov2psdmatrix(observation_noise_cov; d=o)
 
         # _A = x.Σ.R * H'
         # obs_cov = _A'_A + R

--- a/src/data_likelihoods/fenrir.jl
+++ b/src/data_likelihoods/fenrir.jl
@@ -56,15 +56,7 @@ function fenrir_data_loglik(
 
     # Fit the ODE solution / PN posterior to the provided data; this is the actual Fenrir
     o = length(data.u[1])
-    R = if observation_noise_cov isa PSDMatrix
-        observation_noise_cov
-    elseif observation_noise_cov isa Number
-        PSDMatrix(sqrt(observation_noise_cov) * Eye(o))
-    elseif observation_noise_cov isa UniformScaling
-        PSDMatrix(sqrt(observation_noise_cov.λ) * Eye(o))
-    else
-        PSDMatrix(cholesky(observation_noise_cov).U)
-    end
+    R = cov2psdmatrix(observation_noise_cov; d=o)
     LL, _, _ = fit_pnsolution_to_data!(sol, R, data; proj=observation_matrix)
 
     return LL

--- a/src/filtering/update.jl
+++ b/src/filtering/update.jl
@@ -151,9 +151,10 @@ end
 function update!(
     x_out::SRGaussian{T,<:IsometricKroneckerProduct},
     x_pred::SRGaussian{T,<:IsometricKroneckerProduct},
-    measurement::Gaussian{<:AbstractVector,
-                          <:Union{<:PSDMatrix{T,<:IsometricKroneckerProduct},
-                                  <:IsometricKroneckerProduct}},
+    measurement::Gaussian{
+        <:AbstractVector,
+        <:Union{<:PSDMatrix{T,<:IsometricKroneckerProduct},<:IsometricKroneckerProduct},
+    },
     H::IsometricKroneckerProduct,
     K1_cache::IsometricKroneckerProduct,
     K2_cache::IsometricKroneckerProduct,
@@ -169,7 +170,7 @@ function update!(
     _x_pred = Gaussian(reshape_no_alloc(x_pred.μ, Q, d), PSDMatrix(x_pred.Σ.R.B))
     _measurement = Gaussian(
         reshape_no_alloc(measurement.μ, 1, d),
-        measurement.Σ isa PSDMatrix ? PSDMatrix(measurement.Σ.R.B) : measurement.Σ.B
+        measurement.Σ isa PSDMatrix ? PSDMatrix(measurement.Σ.R.B) : measurement.Σ.B,
     )
     _H = H.B
     _K1_cache = K1_cache.B

--- a/src/filtering/update.jl
+++ b/src/filtering/update.jl
@@ -130,7 +130,6 @@ function update!(
         if issuccess(chol)
             copy!(x_out.Σ.R, chol.U)
         else
-            @warn "Cholesky factorization failed. Using triangularize! instead."
             x_out.Σ.R .= triangularize!([x_out.Σ.R; K1_cache']; cachemat=M_cache)
         end
     end

--- a/src/filtering/update.jl
+++ b/src/filtering/update.jl
@@ -130,7 +130,8 @@ function update!(
         if issuccess(chol)
             copy!(x_out.Σ.R, chol.U)
         else
-            x_out.Σ.R .= triangularize!([x_out.Σ.R; R.R * K']; cachemat=M_cache)
+            @warn "Cholesky factorization failed. Using triangularize! instead."
+            x_out.Σ.R .= triangularize!([x_out.Σ.R; K1_cache']; cachemat=M_cache)
         end
     end
 

--- a/src/filtering/update.jl
+++ b/src/filtering/update.jl
@@ -150,7 +150,7 @@ end
 function update!(
     x_out::SRGaussian{T,<:IsometricKroneckerProduct},
     x_pred::SRGaussian{T,<:IsometricKroneckerProduct},
-    measurement::SRGaussian{T,<:IsometricKroneckerProduct},
+    measurement::Gaussian{<:AbstractVector,<:IsometricKroneckerProduct},
     H::IsometricKroneckerProduct,
     K1_cache::IsometricKroneckerProduct,
     K2_cache::IsometricKroneckerProduct,
@@ -164,8 +164,7 @@ function update!(
     Q = D ÷ d            # n_derivatives_dim
     _x_out = Gaussian(reshape_no_alloc(x_out.μ, Q, d), PSDMatrix(x_out.Σ.R.B))
     _x_pred = Gaussian(reshape_no_alloc(x_pred.μ, Q, d), PSDMatrix(x_pred.Σ.R.B))
-    _measurement = Gaussian(
-        reshape_no_alloc(measurement.μ, 1, d), PSDMatrix(measurement.Σ.R.B))
+    _measurement = Gaussian(reshape_no_alloc(measurement.μ, 1, d), measurement.Σ.B)
     _H = H.B
     _K1_cache = K1_cache.B
     _K2_cache = K2_cache.B

--- a/src/filtering/update.jl
+++ b/src/filtering/update.jl
@@ -151,7 +151,9 @@ end
 function update!(
     x_out::SRGaussian{T,<:IsometricKroneckerProduct},
     x_pred::SRGaussian{T,<:IsometricKroneckerProduct},
-    measurement::Gaussian{<:AbstractVector,<:IsometricKroneckerProduct},
+    measurement::Gaussian{<:AbstractVector,
+                          <:Union{<:PSDMatrix{T,<:IsometricKroneckerProduct},
+                                  <:IsometricKroneckerProduct}},
     H::IsometricKroneckerProduct,
     K1_cache::IsometricKroneckerProduct,
     K2_cache::IsometricKroneckerProduct,
@@ -165,7 +167,10 @@ function update!(
     Q = D ÷ d            # n_derivatives_dim
     _x_out = Gaussian(reshape_no_alloc(x_out.μ, Q, d), PSDMatrix(x_out.Σ.R.B))
     _x_pred = Gaussian(reshape_no_alloc(x_pred.μ, Q, d), PSDMatrix(x_pred.Σ.R.B))
-    _measurement = Gaussian(reshape_no_alloc(measurement.μ, 1, d), measurement.Σ.B)
+    _measurement = Gaussian(
+        reshape_no_alloc(measurement.μ, 1, d),
+        measurement.Σ isa PSDMatrix ? PSDMatrix(measurement.Σ.R.B) : measurement.Σ.B
+    )
     _H = H.B
     _K1_cache = K1_cache.B
     _K2_cache = K2_cache.B

--- a/src/initialization/classicsolverinit.jl
+++ b/src/initialization/classicsolverinit.jl
@@ -119,7 +119,8 @@ function rk_init_improve(cache::AbstractODEFilterCache, ts, us, dt)
 
         H = cache.E0 * PI
         measurement.μ .= H * x_pred.μ .- u
-        fast_X_A_Xt!(measurement.Σ, x_pred.Σ, H)
+        _matmul!(cache.C_Dxd, cache.x_pred.Σ.R, cache.H')
+        _matmul!(cache.measurement.Σ, cache.C_Dxd', cache.C_Dxd)
 
         update!(x_filt, x_pred, measurement, H, K1, C_Dxd, C_DxD, C_dxd, C_d)
         push!(filts, copy(x_filt))

--- a/src/initialization/classicsolverinit.jl
+++ b/src/initialization/classicsolverinit.jl
@@ -119,8 +119,8 @@ function rk_init_improve(cache::AbstractODEFilterCache, ts, us, dt)
 
         H = cache.E0 * PI
         measurement.μ .= H * x_pred.μ .- u
-        _matmul!(cache.C_Dxd, cache.x_pred.Σ.R, cache.H')
-        _matmul!(cache.measurement.Σ, cache.C_Dxd', cache.C_Dxd)
+        _matmul!(C_Dxd, x_pred.Σ.R, H')
+        _matmul!(measurement.Σ, C_Dxd', C_Dxd)
 
         update!(x_filt, x_pred, measurement, H, K1, C_Dxd, C_DxD, C_dxd, C_d)
         push!(filts, copy(x_filt))

--- a/src/initialization/common.jl
+++ b/src/initialization/common.jl
@@ -128,7 +128,8 @@ function init_condition_on!(
     m_tmp.μ .-= data
 
     # measurement cov
-    fast_X_A_Xt!(m_tmp.Σ, x.Σ, H)
+    _matmul!(C_Dxd, x.Σ.R, H')
+    _matmul!(m_tmp.Σ, C_Dxd', C_Dxd)
     copy!(x_tmp, x)
     update!(x, x_tmp, m_tmp, H, K1, C_Dxd, C_DxD, C_dxd, C_d)
 end


### PR DESCRIPTION
This PR implements the option to specify an observation noise for the PN likelihood. Fixes #298.

Biggest actual change: The measurement covariance `S` is now an actual matrix, not a `PSDMatrix` anymore. Apparently that's good enough for our case anyways.