### PR TITLE
Fix the solution sampling code

### DIFF
--- a/src/solution_sampling.jl
+++ b/src/solution_sampling.jl
@@ -20,7 +20,8 @@ end
 function sample(sol::ProbODESolution, n::Int=1)
     @unpack d, q = sol.cache
     sample_path = sample_states(sol, n)
-    return sample_path[:, 1:q+1:d*(q+1), :]
+    ys = cat(map(x -> (sol.cache.SolProj * x')', eachslice(sample_path; dims=3))...; dims=3)
+    return ys
 end
 function sample_states(ts, xs, diffusions, difftimes, cache, n::Int=1)
     @assert length(diffusions) + 1 == length(difftimes)
@@ -81,5 +82,6 @@ end
 function dense_sample(sol::ProbODESolution, n::Int=1; density=1000)
     samples, times = dense_sample_states(sol, n; density=density)
     @unpack d, q = sol.cache
-    return samples[:, 1:q+1:d*(q+1), :], times
+    ys = cat(map(x -> (sol.cache.SolProj * x')', eachslice(samples; dims=3))...; dims=3)
+    return ys, times
 end

--- a/test/solution.jl
+++ b/test/solution.jl
@@ -84,7 +84,7 @@ using ODEProblemLibrary: prob_ode_lotkavolterra
             end
 
             # Sampling
-            if Alg == EK1 @testset "Solution Sampling" begin
+            @testset "Solution Sampling" begin
                 @testset "Discrete" begin
                     n_samples = 10
 
@@ -103,18 +103,25 @@ using ODEProblemLibrary: prob_ode_lotkavolterra
                         (2, (0.8, 0.99)),
                         (3, (0.95, 1)),
                         (4, (0.99, 1)),
-                        )
-                        percent_in_interval = sum(
-                            (sum(abs.(us .- samples[:, :, i]') .<= interval_width * es)
-                             for i in 1:n_samples)
-                        ) / (m*n*o)
+                    )
+                        percent_in_interval =
+                            sum(
+                                (
+                                sum(
+                                    abs.(us .- samples[:, :, i]') .<=
+                                    interval_width * es,
+                                )
+                                for i in 1:n_samples
+                            )
+                            ) / (m * n * o)
                         @test low <= percent_in_interval <= high
                     end
                 end
 
                 @testset "Dense" begin
                     n_samples = 10
-                    dense_samples, dense_times = ProbNumDiffEq.dense_sample(sol, n_samples)
+                    dense_samples, dense_times =
+                        ProbNumDiffEq.dense_sample(sol, n_samples)
 
                     m, n, o = size(dense_samples)
                     @test m == length(dense_times)
@@ -132,39 +139,15 @@ using ODEProblemLibrary: prob_ode_lotkavolterra
                         percent_in_interval =
                             sum(
                                 (
-                                    sum(
-                                        abs.(us .- dense_samples[:, :, i]') .<=
-                                            interval_width * es,
-                                    )
-                                    for i in 1:n_samples
-                                        )
+                                sum(
+                                    abs.(us .- dense_samples[:, :, i]') .<=
+                                    interval_width * es,
+                                )
+                                for i in 1:n_samples
+                            )
                             ) / (m * n * o)
                         @test_broken low <= percent_in_interval <= high
                     end
-                end
-            end
-            end
-
-            @testset "Sampling states from the solution" begin
-                if Alg == EK1
-                    n_samples = 2
-
-                    samples = ProbNumDiffEq.sample_states(sol, n_samples)
-
-                    @test samples isa Array
-
-                    m, n, o = size(samples)
-                    @test m == length(sol)
-                    @test n == sol.cache.d * (sol.cache.q + 1)
-                    @test o == n_samples
-
-                    # Dense sampling
-                    dense_samples, dense_times =
-                        ProbNumDiffEq.dense_sample_states(sol, n_samples)
-                    m, n, o = size(dense_samples)
-                    @test m == length(dense_times)
-                    @test n == sol.cache.d * (sol.cache.q + 1)
-                    @test o == n_samples
                 end
             end
 


### PR DESCRIPTION
Currently its output is incorrect. This PR should fix it. Note that the solution sampling is undocumented so this PR should not affect any public API.

Apparently dense sampling is broken! This is most likely due to how diffusions are handled by the interplation->sampling part. Probably, the time-varying diffusions should be stored in such a way that it's clear which ones should be active for which interval, directly in `.diffusions`.