### PR TITLE
Access postamble! via SciMLBase instead of OrdinaryDiffEqCore

### DIFF
--- a/docs/src/implementation.md
+++ b/docs/src/implementation.md
@@ -16,7 +16,7 @@ In particular:
    - `OrdinaryDiffEq.loopheader!`
    - `OrdinaryDiffEq.perform_step!`
    - `OrdinaryDiffEq.loopfooter!`
-   - `OrdinaryDiffEq.postamble!`
+   - `SciMLBase.postamble!`
 
 ProbNumDiffEq.jl builds around this structure and overloads some of the parts:
 
@@ -27,7 +27,7 @@ ProbNumDiffEq.jl builds around this structure and overloads some of the parts:
   - `./src/caches.jl` implements the cache and its main constructor: `OrdinaryDiffEq.alg_cache`
 - **Initialization and `perform_step!`:** via `OrdinaryDiffEq.initialize!` and `OrdinaryDiffEq.perform_step!`.
   Implemented in `./src/perform_step.jl`.
-- **Custom postamble** by overloading `OrdinaryDiffEq.postamble!` (which should always call `OrdinaryDiffEq._postamble!`).
+- **Custom postamble** by overloading `SciMLBase.postamble!` (which should always call `OrdinaryDiffEqCore._postamble!`).
   This is where we do the "smoothing" of the solution.
   Implemented in `./src/integrator_utils.jl`.
 - **Custom saving** by overloading `OrdinaryDiffEq.savevalues!` (which should always call `OrdinaryDiffEq._savevalues!`).

--- a/src/integrator_utils.jl
+++ b/src/integrator_utils.jl
@@ -1,12 +1,12 @@
 """
-    OrdinaryDiffEqCore.postamble!(integ::OrdinaryDiffEqCore.ODEIntegrator{<:AbstractEK})
+    SciMLBase.postamble!(integ::OrdinaryDiffEqCore.ODEIntegrator{<:AbstractEK})
 
-ProbNumDiffEq.jl-specific implementation of OrdinaryDiffEqCore.jl's `postamble!`.
+ProbNumDiffEq.jl-specific implementation of SciMLBase's `postamble!` hook.
 
 In addition to calling `OrdinaryDiffEqCore._postamble!(integ)`, calibrate the diffusion and
 smooth the solution.
 """
-function OrdinaryDiffEqCore.postamble!(
+function SciMLBase.postamble!(
     integ::OrdinaryDiffEqCore.ODEIntegrator{<:AbstractEK},
 )
     # OrdinaryDiffEqCore.jl-related calls:

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -37,12 +37,7 @@ NONPUBLIC_ACCESSES = (
 @test check_no_stale_explicit_imports(ProbNumDiffEq) === nothing
 @test check_no_self_qualified_accesses(ProbNumDiffEq) === nothing
 @test check_all_explicit_imports_via_owners(ProbNumDiffEq) === nothing
-# `postamble!` moved from SciMLBase to OrdinaryDiffEqCore between the OrdinaryDiffEqCore
-# versions in our compat range, so we cannot access it via a fixed owner.
-@test check_all_qualified_accesses_via_owners(
-    ProbNumDiffEq;
-    ignore=(:postamble!,),
-) === nothing
+@test check_all_qualified_accesses_via_owners(ProbNumDiffEq) === nothing
 
 # SciML only started declaring its downstream-facing API `public` in mid-2026
 # (SciMLBase#1401, OrdinaryDiffEq#3787). Test-dependency version constraints can still
@@ -62,6 +57,8 @@ OWN_INTERNALS_USED_BY_EXTENSIONS = (
 )
 
 if SCIML_DECLARES_PUBLIC_API
+    # Owned by SciMLBase, not OrdinaryDiffEqCore (OrdinaryDiffEq#4119).
+    @test Base.ispublic(ProbNumDiffEq.SciMLBase, :postamble!)
     @test check_all_explicit_imports_are_public(ProbNumDiffEq) === nothing
     @test check_all_qualified_accesses_are_public(
         ProbNumDiffEq;


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

Alternative to https://github.com/nathanaelbosch/ProbNumDiffEq.jl/pull/430: do not add `postamble!` to `NONPUBLIC_ACCESSES`.

## What changed and why

OrdinaryDiffEqCore v4.14 dropped its public re-declaration of `postamble!` in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4119. That was intentional: SciMLBase owns the generic and already made it public in https://github.com/SciML/SciMLBase.jl/pull/1470 (SciMLBase v3.40+). Putting the name back on OrdinaryDiffEqCore would fail `public_reexports`.

This package was extending `OrdinaryDiffEqCore.postamble!`, which ExplicitImports now flags as a non-public qualified access. The same function is still public on the owner, so the EK specialization now goes through `SciMLBase.postamble!` (same pattern DelayDiffEq already uses). `_postamble!` stays on the ignore list; that one is Core-owned and not public.

## Verification

Resolved locally: OrdinaryDiffEqCore 4.15.2, SciMLBase 3.50.0.

`Base.ispublic(SciMLBase, :postamble!) == true`
`Base.ispublic(OrdinaryDiffEqCore, :postamble!) == false`
`SciMLBase.postamble! === OrdinaryDiffEqCore.postamble!`

**Failing before the fix** (`GROUP=CodeQuality` ExplicitImports, unfixed `main`):

```
NonPublicQualifiedAccessException
Module `ProbNumDiffEq` has explicit imports of names from modules in which they are not public:
- `postamble!` is not public in `OrdinaryDiffEqCore` but it was imported from `OrdinaryDiffEqCore` at `src/integrator_utils.jl:9:29`
```

**Passing after the fix** (Julia 1.12.7, `--project=test`):

```
GROUP=CodeQuality: Test Summary: Pass 18 / Total 18  (1m17.8s)
  Aqua, JET, ExplicitImports all green
GROUP=Core:        Test Summary: Pass 907 / Broken 8 / Total 915  (4m28.7s)
  includes Smoothing, which runs the custom postamble
docs/make.jl:      exit 0 (local deploy skipped; two pre-existing Rodas4 @example warnings in tutorials/dae.md)
```

JuliaFormatter on the touched files: no changes. `typos` only reported the pre-existing `pn_` prefix.

## What was not verified

- `GROUP=Solvers` and `GROUP=Interface` (Core already solves with `smooth=true` and hits `postamble!`).
- GPU / allowed-to-fail jobs: none here.

## Review notes

#430 papers over the ExplicitImports failure by treating a public SciMLBase hook as a Core internal. This PR keeps `postamble!` out of `NONPUBLIC_ACCESSES` and also drops the `via_owners` ignore, which was based on the reversed claim that ownership moved from SciMLBase to OrdinaryDiffEqCore.

🤖 Generated with Grok 1.0.5 (5115b46bc9) (model: grok-4.6)
Agent-Session: local session ID 01a047c0-1655-7bc2-ba5c-f07876af701a